### PR TITLE
Batch identifier normalization 

### DIFF
--- a/src/translator_ingest/util/normalize.py
+++ b/src/translator_ingest/util/normalize.py
@@ -22,145 +22,194 @@
 # how the normalization - of the two distinct but interrelated collections
 # containing KGX-coded Biolink entities - is best coordinated.
 #
-from typing import Optional, Dict
+from typing import Optional, List, Dict, Callable
+import logging
+
 from .http import post_query
 
-from biolink_model.datamodel.pydanticmodel_v2 import (
-    KnowledgeLevelEnum,
-    Literal, NamedThing, Association, Gene
-)
+from biolink_model.datamodel.pydanticmodel_v2 import NamedThing, Association
 
+logger = logging.getLogger(__name__)
 
-NODE_NORMALIZER_SERVER = "https://nodenormalization-sri.renci.org/get_normalized_nodes"
-
-def node_normalizer_query(query: Dict) -> Optional[Dict]:
+class Normalizer:
     """
-    Wrapper for Node Normalizer http POST query request.
-    :param query: JSON query input, as a Python dictionary
-    :return: Optional[Dict] JSON-like result as multi-level Python dictionary
-    """
-    return post_query(url=NODE_NORMALIZER_SERVER, query=query, server="Node Normalizer")
-
-# I'm not sure that this method is needed... copied from the
-# reasoner-validator library, just to help thinking about NN
-def convert_to_preferred(curie, allowed_list, nn_query=node_normalizer_query):
-    """
-    Given an input CURIE, consults the Node Normalizer
-     to identify an acceptable CURIE match with prefix
-      as requested in the input 'allowed_list' of prefixes.
-    :param curie: str CURIE identifier of interest to convert to a preferred namespace
-    :param allowed_list: List[str] of one or more acceptable CURIE
-           namespaces from which to find at least one equivalent identifier
-    :param nn_query: Node Normalizer accessor query wrapper
-    :param nn_query: Node Normalizer query accessor method
-    """
-    query = {'curies': [curie]}
-    result = nn_query(query=query)
-    if not (result and curie in result and result[curie] and 'equivalent_identifiers' in result[curie]):
-        return None
-    new_ids = [v['identifier'] for v in result[curie]['equivalent_identifiers']]
-    for nid in new_ids:
-        if nid.split(':')[0] in allowed_list:
-            return nid
-    return None
-
-
-def normalize_node(node: NamedThing, nn_query=node_normalizer_query) -> Optional[NamedThing]:
-    """
-    Calls the Node Normalizer ("NN") with the identifier of the given node
-    and updates the node contents with NN resolved values for canonical identifier,
-    node categories, and cross-references.
-
-    Known limitation: this method does NOT reset the node.category field values at this time.
-
-    :param node: target instance of a class object in the NameThing hierarchy
-    :param nn_query: Node Normalizer accessor query wrapper
-
-    :return: rewritten node entry; None, if a node cannot be resolved in NN
+    Wrapper for Node Normalizer operations.
     """
 
-    assert node.id, "normalize_node(node): empty node identifier?"
+    NODE_NORMALIZER_SERVER = "https://nodenormalization-sri.renci.org/get_normalized_nodes"
 
-    query = {'curies': [node.id]}
-    result = nn_query(query=query)
+    @classmethod
+    def get_normalized_nodes(cls, query: Dict) -> Optional[Dict]:
+        """
+        Wrapper for Node Normalizer http POST query request,
+        implementing a remote web server implementation of the Node Normalizer.
+        :param query: JSON query input, as a Python dictionary
+        :return: Optional[Dict] JSON-like result as multi-level Python dictionary
+        """
+        return post_query(url=cls.NODE_NORMALIZER_SERVER, query=query, server="Node Normalizer")
 
-    # Sanity check about regular NN operation for all queries
-    # that returns a result with key equal to the input node identifier
-    assert node.id in result
+    def __init__(self, endpoint: Callable = get_normalized_nodes):
+        """
+        Constructs a Normalizer instance. See https://nodenormalization-sri.renci.org/docs for parameters of query.
+        :param endpoint: Node Normalizer access method with protocol f(query: Dict) -> Optional[Dict]
+        """
+        self.node_normalizer = endpoint
 
-    # Maybe nothing returned if the node identifier is unknown?
-    if not result[node.id]:
+    # I'm not sure that this method is needed... copied from the
+    # reasoner-validator library, just to help thinking about NN
+    def convert_to_preferred(self, curie: str, allowed_list: List[str]):
+        """
+        Given an input CURIE, consults the Node Normalizer
+         to identify an acceptable CURIE match with prefix
+          as requested in the input 'allowed_list' of prefixes.
+
+        :param curie: str CURIE identifier of interest to convert to a preferred namespace
+        :param allowed_list: List[str] of one or more acceptable CURIE
+               namespaces from which to find at least one equivalent identifier
+        """
+        query = {'curies': [curie]}
+        result = self.node_normalizer(query=query)
+        if not (result and curie in result and result[curie] and 'equivalent_identifiers' in result[curie]):
+            return None
+        new_ids = [v['identifier'] for v in result[curie]['equivalent_identifiers']]
+        for nid in new_ids:
+            if nid.split(':')[0] in allowed_list:
+                return nid
         return None
 
-    # retrieve the NN dictionary result
-    # associated with the input node identifier
-    node_identity = result[node.id]
+    def normalize_identifiers(self, curies: List[str]) -> Dict[str, Optional[str]]:
+        """
+        Calls the Node Normalizer ("NN") with a list of curies,
+        returning a dictionary of canonical identifier mappings.
 
-    # Update the contents of the node with the NN result
-    # The original identifier of the input node may be
-    # demoted to xref, while the canonical identifier is reset
+        :param curies: non-empty list of CURIE identifiers to be normalized
+        :return: dictionary mappings of input identifiers to canonical identifiers (None if unknown)
+        """
+        assert curies, "normalize_identifiers(curies): empty list of CURIE identifiers?"
 
-    # (sanity check for required fields... We assume that they ought to always be present?)
-    assert "id" in node_identity and "identifier" in node_identity["id"]
-    canonical_identifier = node_identity["id"]["identifier"]
-    canonical_name = node_identity["id"]["label"]
+        query = {'curies': curies}
+        result = self.node_normalizer(query=query)
+        assert result, "normalize_identifiers(curies): no result returned from the Node Normalizer?"
 
-    # Sanity check... in case the
-    # original node xref and synonym field are empty (or not...)
-    if node.xref is None:
-        node.xref = list()
+        mappings: Dict[str, Optional[str]] = {}
+        for identifier in curies:
+            # Sanity check: was a result for every input CURIE returned?
+            if identifier not in result:
+                # Sanity check: was a result for every input CURIE returned? Is this really needed?
+                logger.warning(f"normalize_identifiers(curies): input curie '{identifier}' not in result")
+                continue
 
-    if node.synonym is None:
-        node.synonym = list()
+            # Maybe nothing returned if the node identifier is unknown?
+            if not result[identifier]:
+                mappings[identifier] = None
+            else:
+                # Non-trivial result returned
+                # retrieve the NN dictionary result
+                # associated with the input node identifier
+                entry = result[identifier]
 
-    for entry in node_identity["equivalent_identifiers"]:
+                # (sanity check for required fields... We assume that they ought to always be present?)
+                assert "id" in entry and "identifier" in entry["id"]
+                mappings[identifier] = entry["id"]["identifier"]
 
-        # Don't include the canonical entry as xref
-        if entry["identifier"] == canonical_identifier:
-            continue
+        return mappings
 
-        # Otherwise, capture equivalent identifier as xref...
-        if entry["identifier"] not in node.xref:
-            node.xref.append(entry["identifier"])
-        # ... and label as a synonym (except for the canonical name)
-        if "label" in entry and \
-                entry["label"] != canonical_name and \
-                entry["label"] not in node.synonym:
-            node.synonym.append(entry["label"])
 
-    if node.id != canonical_identifier:
+    def normalize_node(self, node: NamedThing) -> Optional[NamedThing]:
+        """
+        Calls the Node Normalizer ("NN") with the identifier of the given node
+        and updates the node contents with NN resolved values for canonical identifier,
+        node categories, and cross-references.
 
-        # Reset the node.id to the canonical id...
-        node.id = canonical_identifier
+        Known limitation: this method does NOT reset the node.category field values at this time.
 
-        # Add input.name moved to the list of synonyms
-        # if it is identical to the canonical name
-        if node.name != canonical_name and \
-                node.name not in node.synonym:
-            node.synonym.append(node.name)
+        :param node: target instance of a class object in the NameThing hierarchy
+        :return: rewritten node entry; None, if a node cannot be resolved in NN
+        """
 
-    # Overwrite the node name with the canonical name...
-    node.name = canonical_name
+        assert node.id, "normalize_node(node): empty node identifier?"
 
-    # ... TODO: (Re-)set the node categories
-    #           (Pydantic doesn't allow the following statement ... yet?)
-    # node.category = node_identity["type"]
+        query = {'curies': [node.id]}
+        result = self.node_normalizer(query=query)
 
-    # return the normalized node
-    return node
+        # Sanity check about regular NN operation for all queries
+        # that returns a result with key equal to the input node identifier
+        assert node.id in result
 
-def normalize_edge(edge: Association, nn_query=node_normalizer_query) -> Optional[Association]:
-    """
-    Rewrites the Association subject and object identifiers with their Node Normalizer canonical identifiers.
-    :param edge: target instance of a class object in the Association hierarchy
-    :param nn_query: Node Normalizer accessor query wrapper
+        # Maybe nothing returned if the node identifier is unknown?
+        if not result[node.id]:
+            return None
 
-    rewritten node entry; None, if an association subject or object cannot be resolved in NN
-    """
-    edge_subject = normalize_node(NamedThing(id=edge.subject, **{}), nn_query=nn_query)
-    edge_object = normalize_node(NamedThing(id=edge.object, **{}), nn_query=nn_query)
-    if not (edge_subject and edge_object):
-        return None
-    edge.subject = edge_subject.id
-    edge.object = edge_object.id
-    return edge
+        # retrieve the NN dictionary result
+        # associated with the input node identifier
+        node_identity = result[node.id]
+
+        # Update the contents of the node with the NN result
+        # The original identifier of the input node may be
+        # demoted to xref, while the canonical identifier is reset
+
+        # (sanity check for required fields...
+        #  We assume that they ought to always be present?)
+        assert "id" in node_identity and "identifier" in node_identity["id"]
+        canonical_identifier = node_identity["id"]["identifier"]
+        canonical_name = node_identity["id"]["label"]
+
+        # Sanity check... in case the
+        # original node xref and synonym field are empty (or not...)
+        if node.xref is None:
+            node.xref = list()
+
+        if node.synonym is None:
+            node.synonym = list()
+
+        for entry in node_identity["equivalent_identifiers"]:
+
+            # Don't include the canonical entry as xref
+            if entry["identifier"] == canonical_identifier:
+                continue
+
+            # Otherwise, capture equivalent identifier as xref...
+            if entry["identifier"] not in node.xref:
+                node.xref.append(entry["identifier"])
+            # ... and label as a synonym (except for the canonical name)
+            if "label" in entry and \
+                    entry["label"] != canonical_name and \
+                    entry["label"] not in node.synonym:
+                node.synonym.append(entry["label"])
+
+        if node.id != canonical_identifier:
+
+            # Reset the node.id to the canonical id...
+            node.id = canonical_identifier
+
+            # Add input.name moved to the list of synonyms
+            # if it is identical to the canonical name
+            if node.name != canonical_name and \
+                    node.name not in node.synonym:
+                node.synonym.append(node.name)
+
+        # Overwrite the node name with the canonical name...
+        node.name = canonical_name
+
+        # ... TODO: (Re-)set the node categories
+        #           (Pydantic doesn't allow the following statement ... yet?)
+        # node.category = node_identity["type"]
+
+        # return the normalized node
+        return node
+
+    def normalize_edge(self, edge: Association) -> Optional[Association]:
+        """
+        Rewrites the Association subject and object identifiers with their Node Normalizer canonical identifiers.
+
+        :param edge: target instance of a class object in the Association hierarchy
+
+        :return: rewritten edge Association entry; None, if edge subject or object identifier cannot be resolved in NN
+        """
+        edge_subject = self.normalize_node(NamedThing(id=edge.subject, **{}))
+        edge_object = self.normalize_node(NamedThing(id=edge.object, **{}))
+        if not (edge_subject and edge_object):
+            return None
+        edge.subject = edge_subject.id
+        edge.object = edge_object.id
+        return edge

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -3,7 +3,7 @@ from typing import Dict
 # def post_query(url: str, query: Dict, params=None, server: str = "") -> Dict:
 from src.translator_ingest.util.http import post_query
 
-from src.translator_ingest.util.normalize import NODE_NORMALIZER_SERVER
+from src.translator_ingest.util.normalize import Normalizer
 
 def test_post_invalid_url_query():
     returned: Dict = post_query(url="http://fake-url", query={})
@@ -11,5 +11,5 @@ def test_post_invalid_url_query():
 
 
 def test_post_query():
-    returned: Dict = post_query(url=NODE_NORMALIZER_SERVER, query={'curies': ["HGNC:12791"]})
+    returned: Dict = post_query(url=Normalizer.NODE_NORMALIZER_SERVER, query={'curies': ["HGNC:12791"]})
     assert "HGNC:12791" in returned.keys()


### PR DESCRIPTION
Batch identifier normalization with normalize_identifiers(self, curies: List[str]) -> Dict[str, Optional[str]];  See https://github.com/NCATSTranslator/translator-ingests/blob/batch-identifier-normalization/tests/unit/test_normalization.py#L162 for usage

The normalize library set of methods now encapsulated within a class