### PR TITLE
Revert pandas to pre-3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "koza>=2.1.1",
     "mkdocs-minify-plugin>=0.8.0",
     "openpyxl",      # for pandas read_excel to work, needed for specific ingest
-    "pandas<3.0",    # also installs numpy, used by some ingests
+    "pandas==2.3.3",    # also installs numpy, used by some ingests
     "psycopg[binary]",     # for Postgres querying, needed for specific ingest
     "polars>=1.35.2",
     "requests",    ## needed for specific ingest

--- a/uv.lock
+++ b/uv.lock
@@ -319,7 +319,7 @@ requires-dist = [
     { name = "koza", specifier = ">=2.1.1" },
     { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
     { name = "openpyxl" },
-    { name = "pandas", specifier = "<3.0" },
+    { name = "pandas", specifier = "==2.3.3" },
     { name = "polars", specifier = ">=1.35.2" },
     { name = "psycopg", extras = ["binary"] },
     { name = "requests" },


### PR DESCRIPTION
**URGENT**

In https://github.com/NCATSTranslator/translator-ingests/pull/249, pandas was updated to [3.0](https://pandas.pydata.org/community/blog/pandas-3.0.html). I did not do this on purpose and don't consider it required for this ingest. 

I think this pandas is causing ~other ingests~ the **gene2phenotype** ingest to fail. 

Currently, the **gene2phenotype** ingest is hitting a TypeError during the transform/generating edges and exiting early/producing a truncated set of files. I've found that this problem started occurring after that PR was merged and pandas was updated. If I revert pandas, this problem doesn't occur. 

---

@sierra-moxon 

When I run `uv sync` with this modified pyproject file, linkml and linkml-runtime downgrade too to 1.9.4/1.9.5. So the uv.lock file in this PR has those downgraded versions. 

But I can't find where it states pandas is a dependency for either of them. Is this downgrading a problem? Can you investigate what's going on? 

```
 - bridge==0.1.0.post201.dev0+9dba170c (from file:///Users/colleenxu/Desktop/translator-ingests)
 + bridge==0.1.0.post202.dev0+1d6ef709 (from file:///Users/colleenxu/Desktop/translator-ingests)
 - linkml==1.10.0rc3.post14.dev0+a9b2018d (from git+https://github.com/linkml/linkml.git@a9b2018df2f494ee95edcbff90cc69ac04e4f910#subdirectory=packages/linkml)
 + linkml==1.9.4
 - linkml-runtime==1.10.0rc3.post14.dev0+a9b2018d (from git+https://github.com/linkml/linkml.git@a9b2018df2f494ee95edcbff90cc69ac04e4f910#subdirectory=packages/linkml_runtime)
 + linkml-runtime==1.9.5
 - pandas==3.0.0
 + pandas==2.3.3
 + pytz==2025.2
```