### PR TITLE
Complete SemMedDB manual QA updates #252

### DIFF
--- a/src/translator_ingest/ingests/semmeddb/semmeddb.py
+++ b/src/translator_ingest/ingests/semmeddb/semmeddb.py
@@ -4,9 +4,12 @@ from koza.model.graphs import KnowledgeGraph
 
 from biolink_model.datamodel.pydanticmodel_v2 import (
     AnatomicalEntity,
+    CausalGeneToDiseaseAssociation,
     ChemicalEntity,
+    ChemicalOrGeneOrGeneProductFormOrVariantEnum,
     Disease,
     Gene,
+    GeneToPhenotypicFeatureAssociation,
     NamedThing,
     PhenotypicFeature,
     Protein,
@@ -36,6 +39,30 @@ PREFIX_TO_CLASS = {
 
 def get_latest_version() -> str:
     return "semmeddb-2023-kg2.10.3"
+
+PREDICATE_REMAP = {
+    "biolink:preventative_for_condition": "biolink:treats_or_applied_or_studied_to_treat",
+}
+
+GENETIC_VARIANT_FORM = ChemicalOrGeneOrGeneProductFormOrVariantEnum.genetic_variant_form
+
+
+def _get_node_class(curie: str) -> type[NamedThing]:
+    if ":" not in curie:
+        return NamedThing
+    return PREFIX_TO_CLASS.get(curie.split(":", 1)[0], NamedThing)
+
+
+def _is_gene_or_protein(curie: str) -> bool:
+    return _get_node_class(curie) in {Gene, Protein}
+
+
+def _is_disease(curie: str) -> bool:
+    return _get_node_class(curie) is Disease
+
+
+def _is_phenotypic_feature(curie: str) -> bool:
+    return _get_node_class(curie) is PhenotypicFeature
 
 
 def _extract_supporting_studies(
@@ -229,17 +256,34 @@ def transform_semmeddb_edge(koza: koza.KozaTransform, record: dict[str, Any]) ->
     publications_info = record.get("publications_info", {})
     supporting_studies = _extract_supporting_studies(publications_info)
     
-    # create association between nodes
-    association = Association(
-        id=entity_id(),
-        subject=subject_id,
-        predicate=predicate,
-        object=object_id,
-        publications=publications,
-        sources=build_association_knowledge_sources(primary=INFORES_SEMMEDDB),
-        knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
-        agent_type=AgentTypeEnum.automated_agent,
-    )
+    predicate = PREDICATE_REMAP.get(predicate, predicate)
+
+    association_kwargs = {
+        "id": entity_id(),
+        "subject": subject_id,
+        "predicate": predicate,
+        "object": object_id,
+        "publications": publications,
+        "sources": build_association_knowledge_sources(primary=INFORES_SEMMEDDB),
+        "knowledge_level": KnowledgeLevelEnum.not_provided,
+        "agent_type": AgentTypeEnum.text_mining_agent,
+    }
+
+    if predicate == "biolink:causes" and _is_gene_or_protein(subject_id):
+        if _is_disease(object_id):
+            association = CausalGeneToDiseaseAssociation(
+                **association_kwargs,
+                subject_form_or_variant_qualifier=GENETIC_VARIANT_FORM,
+            )
+        elif _is_phenotypic_feature(object_id):
+            association = GeneToPhenotypicFeatureAssociation(
+                **association_kwargs,
+                subject_form_or_variant_qualifier=GENETIC_VARIANT_FORM,
+            )
+        else:
+            association = Association(**association_kwargs)
+    else:
+        association = Association(**association_kwargs)
     
     # attach supporting studies with text if we extracted any
     if supporting_studies:

--- a/src/translator_ingest/ingests/semmeddb/semmeddb_rig.yaml
+++ b/src/translator_ingest/ingests/semmeddb/semmeddb_rig.yaml
@@ -27,12 +27,9 @@ ingest_info:
       description: "KGX-compatible nodes referenced by the edges subset."
 
   included_content:
-    # Manual QA 1 fix: We include 10 predicates from the source data. We used to have
-    # physically_interacts_with in the config but it had no matching edges in the source,
-    # so we removed it.
     - file_name: "kg2.10.3-semmeddb-edges.jsonl"
-      included_records: "Edges whose predicate is in the selected Biolink predicate set: biolink:treats_or_applied_or_studied_to_treat, biolink:affects, biolink:preventative_for_condition, biolink:coexists_with, biolink:causes, biolink:related_to, biolink:interacts_with, biolink:located_in, biolink:predisposes_to_condition, biolink:disrupts. These are mapped from the following source SEMMEDDB predicates: SEMMEDDB:ADMINISTERED_TO, SEMMEDDB:AFFECTS, SEMMEDDB:ASSOCIATED_WITH, SEMMEDDB:AUGMENTS, SEMMEDDB:CAUSES, SEMMEDDB:COEXISTS_WITH, SEMMEDDB:COMPARED_WITH, SEMMEDDB:DISRUPTS, SEMMEDDB:HIGHER_THAN, SEMMEDDB:INHIBITS, SEMMEDDB:INTERACTS_WITH, SEMMEDDB:ISA, SEMMEDDB:LOCATION_OF (invert), SEMMEDDB:LOWER_THAN, SEMMEDDB:MEASURES, SEMMEDDB:PREDISPOSES, SEMMEDDB:PREVENTS, SEMMEDDB:STIMULATES, SEMMEDDB:TREATS, SEMMEDDB:XREF. Edges retain evidence and negation flags."
-      fields_used: "subject, predicate, object, publications, publications_info, negated, domain_range_exclusion, provided_by, knowledge_level, agent_type"
+      included_records: "Edges whose source predicate is in the selected Biolink predicate set: biolink:treats_or_applied_or_studied_to_treat, biolink:affects, biolink:preventative_for_condition, biolink:coexists_with, biolink:causes, biolink:related_to, biolink:interacts_with, biolink:located_in, biolink:predisposes_to_condition, biolink:disrupts. These are mapped from SEMMEDDB:ADMINISTERED_TO, SEMMEDDB:AFFECTS, SEMMEDDB:ASSOCIATED_WITH, SEMMEDDB:AUGMENTS, SEMMEDDB:CAUSES, SEMMEDDB:COEXISTS_WITH, SEMMEDDB:COMPARED_WITH, SEMMEDDB:DISRUPTS, SEMMEDDB:HIGHER_THAN, SEMMEDDB:INHIBITS, SEMMEDDB:INTERACTS_WITH, SEMMEDDB:ISA, SEMMEDDB:LOCATION_OF (invert), SEMMEDDB:LOWER_THAN, SEMMEDDB:MEASURES, SEMMEDDB:PREDISPOSES, SEMMEDDB:PREVENTS, SEMMEDDB:STIMULATES, SEMMEDDB:TREATS, and SEMMEDDB:XREF. During transform, biolink:preventative_for_condition is remapped to biolink:treats_or_applied_or_studied_to_treat."
+      fields_used: "subject, predicate, object, publications, publications_info, negated, domain_range_exclusion, subject_novelty, object_novelty"
     - file_name: "kg2.10.3-semmeddb-nodes.jsonl"
       included_records: "Only nodes referenced by included edges."
       fields_used: "id, name, category, xrefs (as available)"
@@ -72,7 +69,6 @@ ingest_info:
       affected_predicates:
         - "biolink:treats_or_applied_or_studied_to_treat"
         - "biolink:predisposes_to_condition"
-        - "biolink:preventative_for_condition"
       common_mismatched_subjects:
         - "biolink:Procedure"
         - "biolink:Protein"
@@ -98,143 +94,36 @@ ingest_info:
 target_info:
   infores_id: infores:translator-semmeddb-kgx
 
-  # Edge types we actually output (Manual QA 1 fixes)
-  # Note: We removed biolink:physically_interacts_with because the source data
-  # didn't have any edges matching that predicate after our filters ran.
+  # Manual QA fixes
   edge_type_info:
-    - predicate: biolink:affects
+    - predicates:
+        - biolink:affects
+        - biolink:located_in
+        - biolink:related_to
+        - biolink:interacts_with
+        - biolink:coexists_with
+        - biolink:treats_or_applied_or_studied_to_treat
+        - biolink:causes
+        - biolink:disrupts
+        - biolink:predisposes_to_condition
+      knowledge_level:
+        - not_provided
+      agent_type:
+        - text_mining_agent
+      primary_knowledge_sources:
+        - infores:semmeddb
       edge_properties:
         - publications
-        - publications_info
         - has_supporting_studies
-        - supporting_text
-        - negated
-        - domain_range_exclusion
-        - knowledge_level
-        - agent_type
+        - subject_form_or_variant_qualifier
         - original_subject
         - original_object
         - sources
-    - predicate: biolink:located_in
-      edge_properties:
-        - publications
-        - publications_info
-        - has_supporting_studies
-        - supporting_text
-        - negated
-        - domain_range_exclusion
-        - knowledge_level
-        - agent_type
-        - original_subject
-        - original_object
-        - sources
-    - predicate: biolink:related_to
-      edge_properties:
-        - publications
-        - publications_info
-        - has_supporting_studies
-        - supporting_text
-        - negated
-        - domain_range_exclusion
-        - knowledge_level
-        - agent_type
-        - original_subject
-        - original_object
-        - sources
-    - predicate: biolink:interacts_with
-      edge_properties:
-        - publications
-        - publications_info
-        - has_supporting_studies
-        - supporting_text
-        - negated
-        - domain_range_exclusion
-        - knowledge_level
-        - agent_type
-        - original_subject
-        - original_object
-        - sources
-    - predicate: biolink:coexists_with
-      edge_properties:
-        - publications
-        - publications_info
-        - has_supporting_studies
-        - supporting_text
-        - negated
-        - domain_range_exclusion
-        - knowledge_level
-        - agent_type
-        - original_subject
-        - original_object
-        - sources
-    # This predicate has lots of domain/range warnings - see known_issues section above
-    - predicate: biolink:treats_or_applied_or_studied_to_treat
-      edge_properties:
-        - publications
-        - publications_info
-        - has_supporting_studies
-        - supporting_text
-        - negated
-        - domain_range_exclusion
-        - knowledge_level
-        - agent_type
-        - original_subject
-        - original_object
-        - sources
-    - predicate: biolink:causes
-      edge_properties:
-        - publications
-        - publications_info
-        - has_supporting_studies
-        - supporting_text
-        - negated
-        - domain_range_exclusion
-        - knowledge_level
-        - agent_type
-        - original_subject
-        - original_object
-        - sources
-    - predicate: biolink:disrupts
-      edge_properties:
-        - publications
-        - publications_info
-        - has_supporting_studies
-        - supporting_text
-        - negated
-        - domain_range_exclusion
-        - knowledge_level
-        - agent_type
-        - original_subject
-        - original_object
-        - sources
-    # This predicate has domain/range warnings - see known_issues section above
-    - predicate: biolink:predisposes_to_condition
-      edge_properties:
-        - publications
-        - publications_info
-        - has_supporting_studies
-        - supporting_text
-        - negated
-        - domain_range_exclusion
-        - knowledge_level
-        - agent_type
-        - original_subject
-        - original_object
-        - sources
-    # This predicate has domain/range warnings - see known_issues section above
-    - predicate: biolink:preventative_for_condition
-      edge_properties:
-        - publications
-        - publications_info
-        - has_supporting_studies
-        - supporting_text
-        - negated
-        - domain_range_exclusion
-        - knowledge_level
-        - agent_type
-        - original_subject
-        - original_object
-        - sources
+      notes:
+        - "Supporting text snippets are retained in has_supporting_studies -> has_study_results -> supporting_text; there is no top-level supporting_text edge property."
+      ui_explanation: "SemMedDB data are generated by an automated text-mining agent that extracts relationships from biomedical literature. The record represents text evidence that [SUBJECT] and [OBJECT] were reported with [RELATIONSHIP] in the source literature."
+      source_files:
+        - kg2.10.3-semmeddb-edges.jsonl (RTX-KG2 SemMedDB slice)
 
   # Node types we see in the output
   # This is a diverse set because SemMedDB covers many biomedical concepts
@@ -276,6 +165,10 @@ target_info:
     - node_category: biolink:Human
     - node_category: biolink:Event
     - node_category: biolink:PhysiologicalProcess
+
+future_considerations:
+  - category: edge_properties
+    consideration: "Expand SemMedDB evidence payloads (supporting snippets, evidence counts, and confidence scores) after validating downstream UI and KG constraints."
 
 provenance_info:
   contributions:

--- a/tests/unit/ingests/semmeddb/test_semmeddb.py
+++ b/tests/unit/ingests/semmeddb/test_semmeddb.py
@@ -1,9 +1,11 @@
 import pytest
 from biolink_model.datamodel.pydanticmodel_v2 import (
     Association,
+    CausalGeneToDiseaseAssociation,
     ChemicalEntity,
     Disease,
     Gene,
+    GeneToPhenotypicFeatureAssociation,
     Protein,
     KnowledgeLevelEnum,
     AgentTypeEnum,
@@ -61,8 +63,8 @@ def test_therapeutic_edge_entities(therapeutic_edge_output):
     assert association.subject == "CHEBI:15365"
     assert association.object == "MONDO:0005148"
     assert association.publications == ["PMID:12345678", "PMID:87654321", "PMID:11111111", "PMID:22222222"]
-    assert association.knowledge_level == KnowledgeLevelEnum.knowledge_assertion
-    assert association.agent_type == AgentTypeEnum.automated_agent
+    assert association.knowledge_level == KnowledgeLevelEnum.not_provided
+    assert association.agent_type == AgentTypeEnum.text_mining_agent
     
     # verify node creation
     chemical = [e for e in entities if isinstance(e, ChemicalEntity)][0]
@@ -285,3 +287,77 @@ def test_edge_with_publications_info(edge_with_publications_info):
     
     tm_result = study.has_study_results[0]
     assert "Aspirin effectively reduces inflammation in diabetic patients." in tm_result.supporting_text
+
+
+def test_preventative_predicate_remapped():
+    """Test that preventative_for_condition is remapped to treats_or_applied_or_studied_to_treat."""
+    record = {
+        "subject": "CHEBI:15365",
+        "object": "MONDO:0005148",
+        "predicate": "biolink:preventative_for_condition",
+        "publications": ["PMID:12345678", "PMID:87654321", "PMID:11111111", "PMID:22222222"],
+        "negated": False,
+        "domain_range_exclusion": False,
+        "subject_novelty": 1,
+        "object_novelty": 1,
+    }
+    entities = _create_test_runner(record)
+    association = [e for e in entities if isinstance(e, Association)][0]
+    assert association.predicate == "biolink:treats_or_applied_or_studied_to_treat"
+
+
+def test_gene_causes_disease_gets_variant_qualifier():
+    """Test that gene causes disease edges get genetic_variant_form qualifier."""
+    record = {
+        "subject": "NCBIGene:100",
+        "object": "MONDO:0005148",
+        "predicate": "biolink:causes",
+        "publications": ["PMID:12345678", "PMID:87654321", "PMID:11111111", "PMID:22222222"],
+        "negated": False,
+        "domain_range_exclusion": False,
+        "subject_novelty": 1,
+        "object_novelty": 1,
+    }
+    entities = _create_test_runner(record)
+    association = [e for e in entities if isinstance(e, Association)][0]
+
+    assert isinstance(association, CausalGeneToDiseaseAssociation)
+    assert association.subject_form_or_variant_qualifier == "genetic_variant_form"
+
+
+def test_protein_causes_phenotype_gets_variant_qualifier():
+    """Test that protein causes phenotype edges get genetic_variant_form qualifier."""
+    record = {
+        "subject": "PR:P12345",
+        "object": "HP:0000118",
+        "predicate": "biolink:causes",
+        "publications": ["PMID:12345678", "PMID:87654321", "PMID:11111111", "PMID:22222222"],
+        "negated": False,
+        "domain_range_exclusion": False,
+        "subject_novelty": 1,
+        "object_novelty": 1,
+    }
+    entities = _create_test_runner(record)
+    association = [e for e in entities if isinstance(e, Association)][0]
+
+    assert isinstance(association, GeneToPhenotypicFeatureAssociation)
+    assert association.subject_form_or_variant_qualifier == "genetic_variant_form"
+
+
+def test_causes_without_disease_or_phenotype_no_variant_qualifier():
+    """Test that causes edges to unsupported object classes keep generic Association."""
+    record = {
+        "subject": "NCBIGene:100",
+        "object": "UMLS:C0011847",
+        "predicate": "biolink:causes",
+        "publications": ["PMID:12345678", "PMID:87654321", "PMID:11111111", "PMID:22222222"],
+        "negated": False,
+        "domain_range_exclusion": False,
+        "subject_novelty": 1,
+        "object_novelty": 1,
+    }
+    entities = _create_test_runner(record)
+    association = [e for e in entities if isinstance(e, Association)][0]
+
+    assert type(association) is Association
+    assert not hasattr(association, "subject_form_or_variant_qualifier")


### PR DESCRIPTION
I updated the SemMedDB ingest logic so edge metadata now uses `knowledge_level=not_provided` and `agent_type=text_mining_agent`.

I remapped `biolink:preventative_for_condition` to `biolink:treats_or_applied_or_studied_to_treat` in transform output so PREVENTS no longer appears as a separate output predicate.

I added `biolink:subject_form_or_variant_qualifier=genetic_variant_form` for qualifying Gene or Protein `causes` Disease or Phenotypic Feature edges using Biolink valid association classes.

I updated the SemMedDB RIG to match current output behavior and included a direct note that supporting snippets are retained in `has_supporting_studies -> has_study_results -> supporting_text`.

I updated SemMedDB unit tests to validate the remap behavior and qualifier behavior.

I verified current output and validation artifacts after rerun. Output now shows `not_provided` and `text_mining_agent`, no `preventative_for_condition` predicate, and retained snippet support through `has_supporting_studies`.