### PR TITLE
Use deterministic association IDs across all ingests

### DIFF
--- a/pr-description.md
+++ b/pr-description.md
@@ -1,0 +1,199 @@
+# Centralized Deterministic Association IDs
+
+## Summary
+
+Replaces random UUID generation for association edge IDs with deterministic, content-based hashing. This uses biolink-model's new `AssociationIdConfig` feature (branch `issue-1707-deterministic-association-ids`) which generates SHA-256-based IDs from association field values via a Pydantic `model_validator(mode='before')`. The same edge data always produces the same ID, eliminating non-determinism across pipeline runs.
+
+All 29 ingests have been updated: callers no longer pass `id=` when constructing associations, and the biolink model's validator auto-generates IDs from the association's content.
+
+## Architecture
+
+### Singleton auto-configure
+
+The module `src/translator_ingest/util/association_id.py` uses a singleton pattern to configure the ID strategy automatically at import time:
+
+```python
+from biolink_model.datamodel.pydanticmodel_v2 import AssociationIdConfig, IdStrategy
+
+_association_id_strategy_configured = False
+
+def configure_association_ids(
+    strategy: IdStrategy = IdStrategy.ALL_FIELDS,
+    custom_fields: list[str] | None = None,
+    force: bool = False,
+) -> None:
+    global _association_id_strategy_configured
+    if _association_id_strategy_configured and not force:
+        return
+    AssociationIdConfig.strategy = strategy
+    if custom_fields is not None:
+        AssociationIdConfig.custom_fields = custom_fields
+    _association_id_strategy_configured = True
+
+# Apply default configuration on first import
+configure_association_ids()
+```
+
+This is the single place to change the ID strategy for the entire pipeline. The `ALL_FIELDS` strategy hashes all non-None fields on the association to produce a `uuid:` prefixed deterministic ID.
+
+The singleton guard ensures the configuration runs exactly once — at module import time — regardless of how the code is invoked (via `pipeline.py`, Koza directly, or in tests). `pipeline.py` uses a bare `import translator_ingest.util.association_id` to trigger the singleton. The `force=True` parameter allows tests to reconfigure with different strategies.
+
+### How it works
+
+The biolink-model `Association` base class (and all subclasses) now has a `model_validator(mode='before')` that runs before Pydantic field validation. When no `id` is provided (or `id` is `None`), the validator:
+
+1. Collects all non-None field values from the association data
+2. Builds a canonical string representation
+3. Computes a SHA-256 hash
+4. Prefixes it with `uuid:` to produce the ID
+
+When an explicit `id` IS provided, the validator leaves it untouched.
+
+## How ingests changed
+
+### Pattern A: `id=entity_id()` (23 ingests)
+
+The most common pattern. The `entity_id()` call (which generated a random UUID) was removed from all association constructors:
+
+```python
+# Before (ctd.py):
+association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
+    id=entity_id(),
+    subject=chemical.id,
+    predicate="biolink:related_to",
+    object=disease.id,
+    ...
+)
+
+# After:
+association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
+    subject=chemical.id,
+    predicate="biolink:related_to",
+    object=disease.id,
+    ...
+)
+```
+
+The `entity_id` import was cleaned up from files where it was no longer used. Files that still use `entity_id()` for non-Association objects (e.g., `Study` in tmkp.py, `edge_id` in icees.py for `get_edge_class`) retain the import.
+
+### Pattern B: `id=str(uuid.uuid4())` (3 ingests — gtopdb, go_cam, _ingest_template)
+
+Same as Pattern A but using stdlib `uuid` instead of `entity_id()`:
+
+```python
+# Before (gtopdb.py):
+association = ChemicalAffectsGeneAssociation(
+    id=str(uuid.uuid4()),
+    subject=...,
+    ...
+)
+
+# After:
+association = ChemicalAffectsGeneAssociation(
+    subject=...,
+    ...
+)
+```
+
+The `import uuid` was removed from files where it was no longer needed.
+
+### Pattern C: Source ID passthrough (3 ingests — ctkp, dakp, geneticskp)
+
+These ingests prefer the source's own ID when present, falling back to a random UUID when absent. The fallback now produces `None` instead, which triggers deterministic generation:
+
+```python
+# Before (ctkp.py):
+edge_props = {
+    "id": record.get("id", str(uuid.uuid4())),
+    "subject": subject_id,
+    ...
+}
+
+# After:
+edge_props = {
+    "id": record.get("id"),  # None triggers deterministic ID generation
+    "subject": subject_id,
+    ...
+}
+```
+
+Source-provided IDs are still preserved when they exist.
+
+### What was NOT changed
+
+- **RetrievalSource** objects — `RetrievalSource` is not an Association subclass and doesn't have the deterministic ID validator. These continue using `entity_id()` or `str(uuid.uuid4())`:
+  - `util/biolink.py:knowledge_sources_from_trapi()` — `entity_id()` for RetrievalSource
+  - `ctkp.py`, `dakp.py` — `str(uuid.uuid4())` for RetrievalSource
+  - `build_association_knowledge_sources()` from bmt — uses `entity_id()` internally for RetrievalSource
+- **Study / TextMiningStudyResult** objects (tmkp.py, semmeddb.py) — NamedThing subclasses, not Associations
+- **`edge_id` in icees.py / cohd.py** — icees uses `edge_id = entity_id()` for `get_edge_class()` and `get_icees_supporting_study()`, not for association IDs
+
+## Biolink-model branch compatibility fixes
+
+Updating to the `issue-1707-deterministic-association-ids` branch introduced two additional changes beyond deterministic IDs:
+
+1. **semmeddb.py** — `TextMiningStudyResult` and `Study` (NamedThing subclasses) now require an explicit `id`. Added `id=entity_id()` to both constructors and restored the `entity_id` import.
+
+2. **hpoa.py** — `CorrelatedGeneToDiseaseAssociation` no longer accepts `biolink:associated_with` as a predicate. Changed to `biolink:correlated_with` (the semantically appropriate replacement for the "contributes_to" qualified predicate case). Updated the corresponding test expectation.
+
+## Test changes
+
+### New test file: `tests/test_association_ids.py`
+
+10 tests covering the deterministic ID infrastructure:
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_configure_sets_all_fields_strategy` | `configure_association_ids()` sets `IdStrategy.ALL_FIELDS` |
+| `test_configure_sets_custom_strategy_with_fields` | Custom strategy with explicit field list |
+| `test_deterministic_id_generated_without_explicit_id` | Associations get `uuid:` prefixed IDs |
+| `test_same_inputs_produce_same_id` | Identical inputs → identical ID (determinism) |
+| `test_different_inputs_produce_different_ids` | Different inputs → different ID (no collisions) |
+| `test_explicit_id_preserved` | Passing `id="my-explicit-id"` is not overwritten |
+| `test_deterministic_id_on_association_subclass` | Works on subclasses like `ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation` |
+| `test_deterministic_ids_vary_by_content` (3x) | Parametrized across subject/object combinations |
+
+Tests use an `autouse` fixture to reset `AssociationIdConfig` after each test, preventing state leakage.
+
+### Updated test: `tests/unit/ingests/hpoa/test_hpoa.py`
+
+Updated the expected predicate for `CorrelatedGeneToDiseaseAssociation` from `biolink:associated_with` to `biolink:correlated_with` to match the model change.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `pyproject.toml` | biolink-model → `issue-1707-deterministic-association-ids` branch |
+| `src/translator_ingest/util/association_id.py` | **New** — centralized ID configuration |
+| `src/translator_ingest/pipeline.py` | Call `configure_association_ids()` at startup |
+| `src/translator_ingest/ingests/alliance/alliance.py` | Remove `id=entity_id()` from 3 constructors |
+| `src/translator_ingest/ingests/bgee/bgee.py` | Remove `id=entity_id()` from 1 constructor |
+| `src/translator_ingest/ingests/bindingdb/bindingdb.py` | Remove `id=entity_id()` from 1 constructor |
+| `src/translator_ingest/ingests/chembl/chembl.py` | Remove `id=entity_id()` from 4 constructors |
+| `src/translator_ingest/ingests/cohd/cohd.py` | Remove `edge_id` variable and `id=edge_id` |
+| `src/translator_ingest/ingests/ctd/ctd.py` | Remove `id=entity_id()` from 7 constructors |
+| `src/translator_ingest/ingests/ctkp/ctkp.py` | Change `record.get("id", uuid)` → `record.get("id")` |
+| `src/translator_ingest/ingests/dakp/dakp.py` | Change `record.get("id", uuid)` → `record.get("id")` |
+| `src/translator_ingest/ingests/dgidb/dgidb.py` | Remove `id=entity_id()` from 3 constructors |
+| `src/translator_ingest/ingests/diseases/diseases.py` | Remove `id=entity_id()` from 2 constructors |
+| `src/translator_ingest/ingests/drug_rep_hub/drug_rep_hub.py` | Remove `id=entity_id()` from 3 constructors |
+| `src/translator_ingest/ingests/drugcentral/drugcentral.py` | Remove `id=entity_id()` from 1 constructor |
+| `src/translator_ingest/ingests/gene2phenotype/gene2phenotype.py` | Remove `id=entity_id()` from 1 constructor |
+| `src/translator_ingest/ingests/geneticskp/geneticskp.py` | Change `record.get("id", uuid)` → `record.get("id")` |
+| `src/translator_ingest/ingests/go_cam/go_cam.py` | Remove `id=str(uuid.uuid4())` from 1 constructor |
+| `src/translator_ingest/ingests/goa/goa.py` | Remove `id=entity_id()` from 2 constructors |
+| `src/translator_ingest/ingests/gtopdb/gtopdb.py` | Remove `id=str(uuid.uuid4())` from 11 constructors |
+| `src/translator_ingest/ingests/hpoa/hpoa.py` | Remove `id=entity_id()` from 4 constructors; fix predicate |
+| `src/translator_ingest/ingests/icees/icees.py` | Remove `id=entity_id()` from 1 constructor |
+| `src/translator_ingest/ingests/intact/intact.py` | Remove `id=entity_id()` from 1 constructor |
+| `src/translator_ingest/ingests/panther/panther.py` | Remove `id=entity_id()` from 3 constructors |
+| `src/translator_ingest/ingests/pathbank/pathbank.py` | Remove `id=entity_id()` from 15 constructors |
+| `src/translator_ingest/ingests/semmeddb/semmeddb.py` | Remove `id=entity_id()` from 3 assoc constructors; add to Study/TextMiningStudyResult |
+| `src/translator_ingest/ingests/sider/sider.py` | Remove `id=entity_id()` from 1 constructor |
+| `src/translator_ingest/ingests/signor/signor.py` | Remove `id=entity_id()` from 8 constructors |
+| `src/translator_ingest/ingests/tmkp/tmkp.py` | Remove `"id": entity_id()` from assoc_kwargs dict |
+| `src/translator_ingest/ingests/ttd/ttd.py` | Remove `id=entity_id()` from 4 constructors |
+| `src/translator_ingest/ingests/ubergraph/ubergraph.py` | Remove `id=entity_id()` from 1 constructor |
+| `src/translator_ingest/ingests/_ingest_template/_ingest_template.py` | Remove `id=` from 3 template constructors |
+| `tests/test_association_ids.py` | **New** — 10 tests for deterministic ID infrastructure |
+| `tests/unit/ingests/hpoa/test_hpoa.py` | Update expected predicate for model change |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ target-version = ["py312"]
 package = true
 
 [tool.uv.sources]
-biolink-model = { git = "https://github.com/biolink/biolink-model.git", rev = "master" }
+biolink-model = { git = "https://github.com/biolink/biolink-model.git", rev = "issue-1707-deterministic-association-ids" }
 bmt = { git = "https://github.com/biolink/biolink-model-toolkit.git", rev = "master" }
 
 [tool.uv-dynamic-versioning]

--- a/src/translator_ingest/ingests/_ingest_template/_ingest_template.py
+++ b/src/translator_ingest/ingests/_ingest_template/_ingest_template.py
@@ -1,4 +1,3 @@
-import uuid
 import koza
 import pandas as pd
 from typing import Any, Iterable
@@ -13,7 +12,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     Association,
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 from translator_ingest.util.biolink import INFORES_CTD
 
 # !!! README First !!!
@@ -106,7 +105,6 @@ def transform_ingest_by_record(koza: koza.KozaTransform, record: dict[str, Any])
     chemical = ChemicalEntity(id="MESH:" + record["ChemicalID"], name=record["ChemicalName"])
     disease = Disease(id=record["DiseaseID"], name=record["DiseaseName"])
     association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
-        id=entity_id(),
         subject=chemical.id,
         predicate="biolink:related_to",
         object=disease.id,
@@ -130,7 +128,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
         chemical = ChemicalEntity(id="MESH:" + record["ChemicalID"], name=record["ChemicalName"])
         disease = Disease(id=record["DiseaseID"], name=record["DiseaseName"])
         association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
-            id=str(uuid.uuid4()),
             subject=chemical.id,
             predicate="biolink:related_to",
             object=disease.id,
@@ -153,7 +150,6 @@ def transform_ingest_all_streaming(
         chemical = ChemicalEntity(id="MESH:" + record["ChemicalID"], name=record["ChemicalName"])
         disease = Disease(id=record["DiseaseID"], name=record["DiseaseName"])
         association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
-            id=str(uuid.uuid4()),
             subject=chemical.id,
             predicate="biolink:related_to",
             object=disease.id,

--- a/src/translator_ingest/ingests/alliance/alliance.py
+++ b/src/translator_ingest/ingests/alliance/alliance.py
@@ -17,7 +17,7 @@ from koza.model.graphs import KnowledgeGraph
 from loguru import logger
 from pathlib import Path
 
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 from biolink_model.datamodel.pydanticmodel_v2 import (
     Gene,
     GeneToPhenotypicFeatureAssociation,
@@ -236,7 +236,6 @@ def transform_phenotype(
         nodes.append(phenotype)
 
         association = GeneToPhenotypicFeatureAssociation(
-            id=entity_id(),
             subject=gene_id,
             predicate=GeneToPhenotypicFeaturePredicateEnum.biolinkCOLONhas_phenotype,
             object=phenotypic_feature_id,
@@ -316,7 +315,6 @@ def transform_expression(
 
             edges.append(
                 GeneToExpressionSiteAssociation(
-                    id=entity_id(),
                     subject=gene_id,
                     predicate="biolink:expressed_in",
                     object=anatomical_entity_id,
@@ -335,7 +333,6 @@ def transform_expression(
 
             edges.append(
                 GeneToExpressionSiteAssociation(
-                    id=entity_id(),
                     subject=gene_id,
                     predicate="biolink:expressed_in",
                     object=cellular_component_id,

--- a/src/translator_ingest/ingests/bgee/bgee.py
+++ b/src/translator_ingest/ingests/bgee/bgee.py
@@ -16,7 +16,7 @@ from translator_ingest.util.biolink import INFORES_BGEE
 
 from koza.model.graphs import KnowledgeGraph
 
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 
 BIOLINK_EXPRESSED_IN = "biolink:expressed_in"
 
@@ -76,7 +76,6 @@ def transform_bgee_expressed_in(
         raise ValueError(f"In Bgee Ingest; 'Anatomical entity ID' {anatomical_id} does not start with 'CL:' or 'UBERON:'.")
     # Generate our association objects
     association = Association(
-        id=entity_id(),
         subject=gene_id,
         predicate=BIOLINK_EXPRESSED_IN,
         object=anatomical_id,

--- a/src/translator_ingest/ingests/bindingdb/bindingdb.py
+++ b/src/translator_ingest/ingests/bindingdb/bindingdb.py
@@ -11,7 +11,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     KnowledgeLevelEnum,
     AgentTypeEnum
 )
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 from koza.model.graphs import KnowledgeGraph
 
 from translator_ingest.ingests.bindingdb.bindingdb_util import (
@@ -226,7 +226,6 @@ def transform_bindingdb_by_record(
 
     # Edge
     association = ChemicalGeneInteractionAssociation(
-        id=entity_id(),
         subject=chemical.id,
         predicate="biolink:directly_physically_interacts_with",
         object=protein.id,

--- a/src/translator_ingest/ingests/chembl/chembl.py
+++ b/src/translator_ingest/ingests/chembl/chembl.py
@@ -18,7 +18,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
 
 from koza.model.graphs import KnowledgeGraph
 
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 
 from translator_ingest import INGESTS_PARSER_PATH
 
@@ -542,7 +542,6 @@ def get_association(koza, record, action_type_map):
             return [], []
             # Create association
         association = association_class(
-                id=entity_id(),
                 subject=chemical.id,
                 predicate=predicate,
                 object=target.id,
@@ -573,7 +572,6 @@ def get_activity_association(koza: koza.KozaTransform, chemical, target, action_
     predicate = action_type_map["predicate"]
     qualifiers = action_type_map["qualifiers"]
     association = ChemicalAffectsGeneAssociation(
-        id=entity_id(),
         subject=chemical.id,
         predicate=predicate,
         object=target.id,
@@ -597,7 +595,6 @@ def create_chemical_association(koza: koza.KozaTransform, substrate, metabolite,
     connection = koza.state['chembl_db_connection']
     references = get_references(connection, "metabolism_refs", "met_id", record["met_id"])
     association = ChemicalEntityToChemicalEntityAssociation(
-        id=entity_id(),
         subject=substrate.id,
         predicate="biolink:has_metabolite",
         object=metabolite.id,
@@ -617,7 +614,6 @@ def get_has_part_association(koza: koza.KozaTransform, component, target, record
     species_context_qualifier = get_species_context_qualifier(record)
     species_context_qualifier = species_context_qualifier
     association = AnatomicalEntityHasPartAnatomicalEntityAssociation(
-        id=entity_id(),
         subject=target.id,
         predicate="biolink:has_part",
         object=component.id,

--- a/src/translator_ingest/ingests/cohd/cohd.py
+++ b/src/translator_ingest/ingests/cohd/cohd.py
@@ -11,7 +11,6 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     AgentTypeEnum
 )
 from bmt.pydantic import (
-    entity_id,
     get_node_class,
     # get_edge_class
 )
@@ -109,8 +108,6 @@ def on_end_edge_ingest(koza_transform: koza.KozaTransform) -> None:
 def transform_cohd_edge(koza_transform: koza.KozaTransform, record: dict[str, Any]) -> KnowledgeGraph | None:
 
     try:
-        edge_id = entity_id()
-
         cohd_subject: str = record["subject"]
         # subject_category: list[str] = bmt.get_element_by_prefix(cohd_subject)
 
@@ -137,7 +134,6 @@ def transform_cohd_edge(koza_transform: koza.KozaTransform, record: dict[str, An
         #
         # association = edge_class(
         association = Association(
-            id=edge_id,
             subject=cohd_subject,
             predicate=cohd_predicate,
             object=cohd_object,

--- a/src/translator_ingest/ingests/ctd/ctd.py
+++ b/src/translator_ingest/ingests/ctd/ctd.py
@@ -18,7 +18,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     KnowledgeLevelEnum,
     AgentTypeEnum,
 )
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 from translator_ingest.util.biolink import INFORES_CTD
 
 from bs4 import BeautifulSoup
@@ -76,7 +76,6 @@ def transform_chemical_to_disease(koza: koza.KozaTransform, record: dict[str, An
     predicate = CHEM_TO_DISEASE_PREDICATES[evidence_type]
     publications = [f"PMID:{p}" for p in record["PubMedIDs"].split("|")] if record["PubMedIDs"] else None
     association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
-        id=entity_id(),
         subject=chemical.id,
         predicate=predicate,
         object=disease.id,
@@ -119,7 +118,6 @@ def transform_exposure_events(koza: koza.KozaTransform, record: dict[str, Any]) 
     if disease_id:
         nodes.append(Disease(id=disease_id))
         c_to_d_association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
-                id=entity_id(),
                 subject=exposure_chemical_id,
                 predicate=predicate,
                 object=disease_id,
@@ -136,7 +134,6 @@ def transform_exposure_events(koza: koza.KozaTransform, record: dict[str, Any]) 
     if phenotype_id:
         nodes.append(PhenotypicFeature(id=phenotype_id))
         c_to_p_association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
-                id=entity_id(),
                 subject=exposure_chemical_id,
                 predicate=predicate,
                 object=phenotype_id,
@@ -293,7 +290,6 @@ def transform_chem_gene_ixns(koza: koza.KozaTransform, record: dict[str, Any]) -
     publications = [f'PMID:{pmid}' for pmid in record['PubMedIDs'].split('|')]
 
     association = ChemicalAffectsGeneAssociation(
-        id=entity_id(),
         subject=chemical_id,
         predicate=predicate,
         object=gene_id,
@@ -322,7 +318,6 @@ def transform_chem_go_enriched(koza: koza.KozaTransform, record: dict[str, Any])
     p_value = record['PValue']
     corrected_p_value = record['CorrectedPValue']
     edge = ChemicalEntityToBiologicalProcessAssociation(
-        id=entity_id(),
         subject=chemical_id,
         predicate=BIOLINK_ASSOCIATED_WITH,
         object=go_term,
@@ -347,7 +342,6 @@ def transform_chem_pathways_enriched(koza: koza.KozaTransform, record: dict[str,
     p_value = record['PValue']
     corrected_p_value = record['CorrectedPValue']
     edge = ChemicalEntityToPathwayAssociation(
-        id=entity_id(),
         subject=chemical_id,
         predicate=BIOLINK_ASSOCIATED_WITH,
         object=pathway_id,
@@ -403,7 +397,6 @@ def transform_pheno_term_ixns(koza: koza.KozaTransform, record: dict[str, Any]) 
             koza.transform_metadata['unmapped_pheno_ixn_types'].add(interaction)
 
     edge = ChemicalEntityToBiologicalProcessAssociation(
-        id=entity_id(),
         subject=chemical_id,
         predicate=BIOLINK_AFFECTS,
         object=phenotype_id,

--- a/src/translator_ingest/ingests/ctkp/ctkp.py
+++ b/src/translator_ingest/ingests/ctkp/ctkp.py
@@ -183,7 +183,7 @@ def transform(koza: koza.KozaTransform, record: dict[str, Any]) -> KnowledgeGrap
     qualifiers = record.get("qualifiers", [])
 
     edge_props = {
-        "id": record.get("id", str(uuid.uuid4())),
+        "id": record.get("id"),
         "subject": subject_id,
         "predicate": predicate,
         "object": object_id,

--- a/src/translator_ingest/ingests/dakp/dakp.py
+++ b/src/translator_ingest/ingests/dakp/dakp.py
@@ -147,7 +147,7 @@ def transform(koza: koza.KozaTransform, record: dict[str, Any]) -> KnowledgeGrap
     publications = record.get("publications", [])
 
     edge_props = {
-        "id": record.get("id", str(uuid.uuid4())),
+        "id": record.get("id"),
         "subject": subject_id,
         "predicate": predicate,
         "object": object_id,

--- a/src/translator_ingest/ingests/dgidb/dgidb.py
+++ b/src/translator_ingest/ingests/dgidb/dgidb.py
@@ -3,7 +3,7 @@ import koza
 import pandas as pd
 from typing import Any, Iterable
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 from biolink_model.datamodel.pydanticmodel_v2 import (
     ChemicalEntity,
     Gene,    ## because terms/IDs dgidb gives are for genes
@@ -173,7 +173,6 @@ def transform_row(koza: koza.KozaTransform, record: dict[str, Any]) -> Knowledge
     ## ASSUMING no special logic, so only 1 edge made
     ## NOTE: sometimes supporting sources, publications, scores will be empty (None, empty list). Then don't want them present in output
         association = ChemicalGeneInteractionAssociation(
-            id=entity_id(),
             subject=chemical.id,
             object=gene.id,
             ## KL/AT is for dgidb
@@ -195,7 +194,6 @@ def transform_row(koza: koza.KozaTransform, record: dict[str, Any]) -> Knowledge
     ## NOTE: sometimes supporting sources, publications, scores will be empty (None, empty list). Then don't want them present in output
         ## MAIN EDGE
         association = ChemicalAffectsGeneAssociation(
-            id=entity_id(),
             subject=chemical.id,
             object=gene.id,
             ## KL/AT is for dgidb
@@ -216,7 +214,6 @@ def transform_row(koza: koza.KozaTransform, record: dict[str, Any]) -> Knowledge
             ## SPECIAL logic: create extra "physical interaction" edge for some "affects" edges
             ## should be identical to original edge, except predicate/no qualifiers. And CX decided not to include dgidb scores
             extra_assoc = ChemicalGeneInteractionAssociation(
-                id=entity_id(),
                 subject=chemical.id,
                 object=gene.id,
                 ## KL/AT is for dgidb

--- a/src/translator_ingest/ingests/diseases/diseases.py
+++ b/src/translator_ingest/ingests/diseases/diseases.py
@@ -1,4 +1,3 @@
-from bmt.pydantic import entity_id
 import koza
 from typing import Any, Iterable
 from koza.model.graphs import KnowledgeGraph
@@ -178,8 +177,6 @@ def textmining_transform(koza: koza.KozaTransform, record: dict[str, Any]) -> Kn
     disease = Disease(id=record["disease_id"])
 
     association = CorrelatedGeneToDiseaseAssociation(
-        ## creating arbitrary ID for edge right now
-        id=entity_id(),
         subject=protein.id,
         predicate=BIOLINK_OCCURS_IN_LIT_WITH,
         object=disease.id,
@@ -245,8 +242,6 @@ def knowledge_transform(koza: koza.KozaTransform, record: dict[str, Any]) -> Kno
         )
 
     association = GeneToDiseaseAssociation(
-        ## creating arbitrary ID for edge right now
-        id=entity_id(),
         subject=protein.id,
         predicate=BIOLINK_ASSOCIATED_WITH,
         object=disease.id,

--- a/src/translator_ingest/ingests/drug_rep_hub/drug_rep_hub.py
+++ b/src/translator_ingest/ingests/drug_rep_hub/drug_rep_hub.py
@@ -17,7 +17,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     AgentTypeEnum,
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 
 
 TRANSFORM_VERSION="1.1"
@@ -127,7 +127,6 @@ def create_disease_association(chemical, indication, indication_info, predicate,
     #TODO: clinical_approval_status = clinical_approval_map.get(clinical_phase, None)
     #TODO: max_research_phase = research_phase_map.get(clinical_phase, None)
     association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
-        id = entity_id(),
         subject=chemical.id,
         object=disease.id,
         predicate=predicate,
@@ -148,7 +147,6 @@ def create_chemical_role_association(chemical, indication, indication_info, pred
         name=indication_info['primary_name'] if indication_info['primary_name'] else indication,
     )
     association = ChemicalEntityToChemicalEntityAssociation(
-        id = entity_id(),
         subject=chemical.id,
         predicate=predicate,
         object=chemical_role.id,
@@ -170,7 +168,6 @@ def create_target_association(chemical, target_gene_symbol, moa):
         symbol = target_gene_symbol
     )
     association = ChemicalAffectsGeneAssociation(
-        id = entity_id(),
         subject=chemical.id,
         predicate='biolink:affects',
         object=target.id,

--- a/src/translator_ingest/ingests/drugcentral/drugcentral.py
+++ b/src/translator_ingest/ingests/drugcentral/drugcentral.py
@@ -3,7 +3,7 @@ import koza
 from koza.model.graphs import KnowledgeGraph
 from typing import Any, Iterable
 ## build_association_knowledge_sources should be able to handle source_record_urls
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 ## using bmt to get UMLS semantic types for DiseaseOrPheno
 from translator_ingest.util.biolink import INFORES_DRUGCENTRAL, get_biolink_model_toolkit
 from biolink_model.datamodel.pydanticmodel_v2 import (
@@ -154,7 +154,6 @@ def omop_transform(koza: koza.KozaTransform, record: dict[str, Any]) -> Knowledg
     data_modeling = OMOP_RELATION_MAPPING[record["relationship_name"]]
 
     association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
-        id=entity_id(),
         subject=chemical.id,
         predicate=data_modeling["predicate"],
         object=dop.id,

--- a/src/translator_ingest/ingests/gene2phenotype/gene2phenotype.py
+++ b/src/translator_ingest/ingests/gene2phenotype/gene2phenotype.py
@@ -2,7 +2,6 @@
 import koza
 from typing import Any, Iterable
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id
 from translator_ingest.util.biolink import INFORES_EBI_G2P
 from biolink_model.datamodel.pydanticmodel_v2 import (
     Gene,
@@ -147,8 +146,6 @@ def transform(koza: koza.KozaTransform, record: dict[str, Any]) -> KnowledgeGrap
         disease = Disease(id=record["disease MONDO"])
 
     association = GeneToDiseaseAssociation(
-        ## creating arbitrary ID for edge right now
-        id=entity_id(),
         subject=gene.id,
         predicate=BIOLINK_ASSOCIATED_WITH,
         qualified_predicate=BIOLINK_CAUSES,

--- a/src/translator_ingest/ingests/geneticskp/geneticskp.py
+++ b/src/translator_ingest/ingests/geneticskp/geneticskp.py
@@ -14,7 +14,6 @@ import gzip
 import tarfile
 from pathlib import Path
 from typing import Any, Dict, Optional
-import uuid
 from datetime import datetime
 import koza
 
@@ -198,7 +197,7 @@ def transform(koza: koza.KozaTransform, record: Dict[str, Any]) -> Optional[Know
     
     # Build edge properties
     edge_props = {
-        "id": record.get("id", str(uuid.uuid4())),
+        "id": record.get("id"),
         "subject": subject_id,
         "predicate": predicate,
         "object": object_id,

--- a/src/translator_ingest/ingests/go_cam/go_cam.py
+++ b/src/translator_ingest/ingests/go_cam/go_cam.py
@@ -1,7 +1,6 @@
 import json
 import tarfile
 import tempfile
-import uuid
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -340,7 +339,6 @@ def transform_go_cam_models(koza: koza.KozaTransform, data: Iterable[dict[str, A
 
             # Create the gene-to-gene association
             association = GeneToGeneAssociation(
-                id=str(uuid.uuid4()),
                 subject=normalized_source_id,
                 predicate=biolink_predicate,
                 object=normalized_target_id,

--- a/src/translator_ingest/ingests/goa/goa.py
+++ b/src/translator_ingest/ingests/goa/goa.py
@@ -20,7 +20,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     RNAProduct,
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 from translator_ingest.util.biolink import INFORES_GOA, INFORES_INTACT
 
 # Constants
@@ -294,7 +294,6 @@ def transform_record(koza: koza.KozaTransform, record: dict[str, Any]) -> Iterab
     if biolink_class == Gene:
         # Use GeneToGoTermAssociation for gene entities
         association = GeneToGoTermAssociation(
-            id=entity_id(),
             subject=entity.id,
             predicate=predicate,
             object=go_term.id,
@@ -312,7 +311,6 @@ def transform_record(koza: koza.KozaTransform, record: dict[str, Any]) -> Iterab
     else:
         # Use generic Association for protein, complex, and RNA entities since there are no specific associations
         association = Association(
-            id=entity_id(),
             subject=entity.id,
             predicate=predicate,
             object=go_term.id,

--- a/src/translator_ingest/ingests/gtopdb/gtopdb.py
+++ b/src/translator_ingest/ingests/gtopdb/gtopdb.py
@@ -1,4 +1,3 @@
-import uuid
 import koza
 import pandas as pd
 from typing import Any, Iterable
@@ -92,7 +91,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 causal_mechanism_qualifier = CausalMechanismQualifierEnum.potentiation
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
                 subject=subject.id,
                 object=object.id,
                 predicate = predicate,
@@ -143,7 +141,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 object_direction_qualifier = DirectionQualifierEnum.increased
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
                 subject=subject.id,
                 object=object.id,
                 predicate = predicate,
@@ -219,7 +216,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 qualified_predicate = BIOLINK_CAUSES
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
                 subject=subject.id,
                 object=object.id,
                 predicate = predicate,
@@ -257,7 +253,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 causal_mechanism_qualifier = CausalMechanismQualifierEnum.non_competitive_antagonism
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
                 subject=subject.id,
                 object=object.id,
                 predicate = predicate,
@@ -301,7 +296,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 qualified_predicate = None
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
                 subject=subject.id,
                 object=object.id,
                 predicate = predicate,
@@ -341,7 +335,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 qualified_predicate = None
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
                 subject=subject.id,
                 object=object.id,
                 predicate = predicate,
@@ -367,7 +360,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
             qualified_predicate = BIOLINK_CAUSES
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
                 subject=subject.id,
                 object=object.id,
                 predicate = predicate,
@@ -411,7 +403,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 qualified_predicate = BIOLINK_CAUSES
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
                 subject=subject.id,
                 object=object.id,
                 predicate = predicate,
@@ -453,7 +444,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 causal_mechanism_qualifier = CausalMechanismQualifierEnum.inhibition
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
                 subject=subject.id,
                 object=object.id,
                 predicate = predicate,
@@ -484,7 +474,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 object_direction_qualifier = DirectionQualifierEnum.increased
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
                 subject=subject.id,
                 object=object.id,
                 predicate = predicate,
@@ -515,7 +504,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 object_direction_qualifier = DirectionQualifierEnum.increased
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
                 subject=subject.id,
                 object=object.id,
                 predicate = predicate,

--- a/src/translator_ingest/ingests/hpoa/hpoa.py
+++ b/src/translator_ingest/ingests/hpoa/hpoa.py
@@ -33,7 +33,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
 )
 
 from translator_ingest.util.github import GitHubReleases
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 from translator_ingest.util.biolink import INFORES_HPOA
 
 from translator_ingest.ingests.hpoa.phenotype_ingest_utils import (
@@ -216,7 +216,6 @@ def transform_disease_to_phenotype_edge_record(
 
         # Association/Edge
         association = DiseaseToPhenotypicFeatureAssociation(
-            id=entity_id(),
             subject=disease_id,
             predicate="biolink:has_phenotype",
             negated=negated,
@@ -263,7 +262,6 @@ def transform_gene_to_disease_record(
 
     if qualified_predicate == "biolink:causes":
         association = CausalGeneToDiseaseAssociation(
-            id=entity_id(),
             subject=gene_id,
             predicate="biolink:associated_with",
             object=disease_id,
@@ -276,9 +274,8 @@ def transform_gene_to_disease_record(
         )
     elif qualified_predicate == "biolink:contributes_to":
         association = CorrelatedGeneToDiseaseAssociation(
-            id=entity_id(),
             subject=gene_id,
-            predicate="biolink:associated_with",
+            predicate="biolink:correlated_with",
             object=disease_id,
             qualified_predicate="biolink:contributes_to",
             subject_form_or_variant_qualifier=VE.genetic_variant_form,
@@ -394,7 +391,6 @@ def transform_gene_to_phenotype_record(
     publications = [pub.strip() for pub in str(record["publications"]).split(";")] if record["publications"] else []
 
     association = GeneToPhenotypicFeatureAssociation(
-        id=entity_id(),
         subject=gene_id,
         predicate=GeneToPhenotypicFeaturePredicateEnum.biolinkCOLONassociated_with,
         object=hpo_id,

--- a/src/translator_ingest/ingests/icees/icees.py
+++ b/src/translator_ingest/ingests/icees/icees.py
@@ -142,7 +142,6 @@ def transform_icees_edge(koza_transform: koza.KozaTransform, record: dict[str, A
                 pass # all other attributes ignored at this time
 
         association = edge_class(
-            id=entity_id(),
             subject=icees_subject,
             predicate=icees_predicate,
             object=icees_object,

--- a/src/translator_ingest/ingests/intact/intact.py
+++ b/src/translator_ingest/ingests/intact/intact.py
@@ -12,7 +12,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
 )
 from translator_ingest.util.biolink import INFORES_INTACT
 from translator_ingest.util.http_utils import get_ftp_modify_date
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 from koza.model.graphs import KnowledgeGraph
 
 # Allowed interaction types as per RIG documentation
@@ -403,7 +403,6 @@ def transform_record(koza: koza.KozaTransform, record: dict[str, Any]) -> Knowle
 
     # Create the interaction edge
     interaction = PairwiseMolecularInteraction(
-        id=entity_id(),
         subject=entity_a.id,
         predicate=predicate,
         object=entity_b.id,

--- a/src/translator_ingest/ingests/panther/panther.py
+++ b/src/translator_ingest/ingests/panther/panther.py
@@ -12,7 +12,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     KnowledgeLevelEnum,
     AgentTypeEnum, GeneFamily
 )
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 
 import koza
 from koza.model.graphs import KnowledgeGraph
@@ -115,7 +115,6 @@ def transform_gene_to_gene_orthology(
 
         # Generate our association objects
         orthology_relationship = GeneToGeneHomologyAssociation(
-            id=entity_id(),
             subject=gene_a.id,
             object=gene_b.id,
             predicate="biolink:orthologous_to",
@@ -125,7 +124,6 @@ def transform_gene_to_gene_orthology(
             agent_type=AgentTypeEnum.manual_validation_of_automated_agent
         )
         gene_a_family_relationship = GeneToGeneFamilyAssociation(
-            id=entity_id(),
             subject=gene_a.id,
             object=gene_family.id,
             predicate="biolink:member_of",
@@ -134,7 +132,6 @@ def transform_gene_to_gene_orthology(
             agent_type=AgentTypeEnum.manual_validation_of_automated_agent
         )
         gene_b_family_relationship = GeneToGeneFamilyAssociation(
-            id=entity_id(),
             subject=gene_b.id,
             object=gene_family.id,
             predicate="biolink:member_of",

--- a/src/translator_ingest/ingests/pathbank/pathbank.py
+++ b/src/translator_ingest/ingests/pathbank/pathbank.py
@@ -30,7 +30,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     GeneOrGeneProductOrChemicalEntityAspectEnum,
 )
 
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 from translator_ingest.util.biolink import INFORES_PATHBANK
 from translator_ingest.util.http_utils import get_modify_date
 
@@ -242,7 +242,6 @@ def _create_compound_node_and_edges(
     # Create has_participant edge from pathway to compound (use primary ID)
     pathway_curie = _pathway_id_to_curie(pathway_id)
     has_component_edge = Association(
-        id=entity_id(),
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=primary_curie,
@@ -335,7 +334,6 @@ def _create_protein_node_and_edges(
     # Create has_participant edge from pathway to protein (use primary ID)
     pathway_curie = _pathway_id_to_curie(pathway_id)
     has_component_edge = Association(
-        id=entity_id(),
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=primary_curie,
@@ -416,7 +414,6 @@ def _create_protein_complex_node_and_edges(
     # Create has_protein_in_complex edges
     for protein_id in sorted(set(complex_proteins)):
         has_protein_edge = Association(
-            id=entity_id(),
             subject=pwp_curie,
             predicate="biolink:has_part",
             object=protein_id,
@@ -431,7 +428,6 @@ def _create_protein_complex_node_and_edges(
     # Create has_participant edge from pathway to complex
     pathway_curie = _pathway_id_to_curie(pathway_id)
     has_component_edge = Association(
-        id=entity_id(),
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=pwp_curie,
@@ -510,7 +506,6 @@ def _create_nucleic_acid_node_and_edges(
     # Create has_participant edge from pathway to nucleic acid (use primary ID)
     pathway_curie = _pathway_id_to_curie(pathway_id)
     has_component_edge = Association(
-        id=entity_id(),
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=primary_curie,
@@ -616,7 +611,6 @@ def _create_reaction_node_and_edges(
             else:
                 object_curie = f"{prefix}:{primary_equiv_id}"
             reactant_edge = Association(
-                id=entity_id(),
                 subject=primary_curie,
                 predicate="biolink:has_input",
                 object=object_curie,
@@ -650,7 +644,6 @@ def _create_reaction_node_and_edges(
             else:
                 object_curie = f"{prefix}:{primary_equiv_id}"
             product_edge = Association(
-                id=entity_id(),
                 subject=primary_curie,
                 predicate="biolink:has_output",
                 object=object_curie,
@@ -682,7 +675,6 @@ def _create_reaction_node_and_edges(
             else:
                 subject_curie = f"{prefix}:{primary_equiv_id}"
             enzyme_edge = Association(
-                id=entity_id(),
                 subject=subject_curie,
                 predicate="biolink:catalyzes",
                 object=primary_curie,
@@ -697,7 +689,6 @@ def _create_reaction_node_and_edges(
     # Create has_participant edge from pathway to reaction (use primary ID)
     pathway_curie = _pathway_id_to_curie(pathway_id)
     has_component_edge = Association(
-        id=entity_id(),
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=primary_curie,
@@ -769,7 +760,6 @@ def _create_bound_node_and_edges(
                 continue
 
             has_part_edge = Association(
-                id=entity_id(),
                 subject=pwb_curie,
                 predicate="biolink:has_part",
                 object=object_curie,
@@ -784,7 +774,6 @@ def _create_bound_node_and_edges(
     # Create has_participant edge from pathway to bound
     pathway_curie = _pathway_id_to_curie(pathway_id)
     has_component_edge = Association(
-        id=entity_id(),
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=pwb_curie,
@@ -875,7 +864,6 @@ def _create_element_collection_node_and_edges(
     # Create has_participant edge from pathway to element collection (use primary ID)
     pathway_curie = _pathway_id_to_curie(pathway_id)
     has_component_edge = Association(
-        id=entity_id(),
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=primary_curie,
@@ -1028,7 +1016,6 @@ def _create_interaction_edges(
 
             # Create interaction edge with predicate and qualifiers based on interaction type
             interaction_edge_kwargs = {
-                "id": entity_id(),
                 "subject": left_curie,
                 "predicate": predicate,
                 "object": right_curie,
@@ -1089,7 +1076,6 @@ def _create_subcellular_location_nodes_and_edges(
     # Create occurs_in edge from pathway to location
     pathway_curie = _pathway_id_to_curie(pathway_id)
     occurs_in_edge = Association(
-        id=entity_id(),
         subject=pathway_curie,
         predicate="biolink:occurs_in",
         object=location_curie,
@@ -1142,7 +1128,6 @@ def _create_tissue_nodes_and_edges(
     # Create occurs_in edge from pathway to tissue
     pathway_curie = _pathway_id_to_curie(pathway_id)
     occurs_in_edge = Association(
-        id=entity_id(),
         subject=pathway_curie,
         predicate="biolink:occurs_in",
         object=tissue_curie,

--- a/src/translator_ingest/ingests/semmeddb/semmeddb.py
+++ b/src/translator_ingest/ingests/semmeddb/semmeddb.py
@@ -231,7 +231,6 @@ def transform_semmeddb_edge(koza: koza.KozaTransform, record: dict[str, Any]) ->
     
     # create association between nodes
     association = Association(
-        id=entity_id(),
         subject=subject_id,
         predicate=predicate,
         object=object_id,

--- a/src/translator_ingest/ingests/sider/sider.py
+++ b/src/translator_ingest/ingests/sider/sider.py
@@ -13,7 +13,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     KnowledgeLevelEnum,
     AgentTypeEnum,
 )
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 from translator_ingest import INGESTS_PARSER_PATH
 
 SIDER_INGEST_PATH = INGESTS_PARSER_PATH / "sider"
@@ -80,7 +80,6 @@ def transform_ingest_all_streaming(
             continue
         all_triples.add((chemical.id, predicate, disease.id))
         association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
-            id=entity_id(),
             subject=chemical.id,
             predicate=predicate,
             object=disease.id,

--- a/src/translator_ingest/ingests/signor/signor.py
+++ b/src/translator_ingest/ingests/signor/signor.py
@@ -19,7 +19,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     KnowledgeLevelEnum,
     AgentTypeEnum,
 )
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 from koza.model.graphs import KnowledgeGraph
 from translator_ingest.util.biolink import (
     INFORES_SIGNOR
@@ -147,7 +147,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 raise NotImplementedError(f'Effect {record["EFFECT"]} could not be mapped to required qualifiers.')
 
             association = GeneRegulatesGeneAssociation(
-                id=entity_id(),
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:regulates",
@@ -169,7 +168,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
 
             if record["EFFECT"] == 'form complex':
                 association_1 = AnatomicalEntityHasPartAnatomicalEntityAssociation(
-                    id=entity_id(),
                     subject=subject.id,
                     object=object.id,
                     predicate = "biolink:has_part",
@@ -179,7 +177,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 )
 
                 association_2 = PairwiseMolecularInteraction(
-                    id=entity_id(),
                     subject=subject.id,
                     object=object.id,
                     predicate = "biolink:physically_interacts_with",
@@ -220,7 +217,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 raise NotImplementedError(f'Effect {record["EFFECT"]} could not be mapped to required qualifiers.')
 
             association = GeneAffectsChemicalAssociation(
-                id=entity_id(),
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:affects",
@@ -271,7 +267,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 raise NotImplementedError(f'Effect {record["EFFECT"]} could not be mapped to required qualifiers.')
 
             association = GeneRegulatesGeneAssociation(
-                id=entity_id(),
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:affects",
@@ -313,7 +308,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 raise NotImplementedError(f'Effect {record["EFFECT"]} could not be mapped to required qualifiers.')
 
             association = GeneRegulatesGeneAssociation(
-                id=entity_id(),
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:affects",
@@ -344,7 +338,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 raise NotImplementedError(f'Effect {record["EFFECT"]} could not be mapped to required qualifiers.')
 
             association = ChemicalEntityToChemicalEntityAssociation(
-                id=entity_id(),
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:affects",
@@ -391,7 +384,6 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 object_direction_qualifier = DirectionQualifierEnum.downregulated
 
             association = ChemicalEntityToChemicalEntityAssociation(
-                id=entity_id(),
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:affects",

--- a/src/translator_ingest/ingests/tmkp/tmkp.py
+++ b/src/translator_ingest/ingests/tmkp/tmkp.py
@@ -153,7 +153,6 @@ def transform_tmkp_edge(koza_transform: koza.KozaTransform, record: Dict[str, An
 
         # Build association kwargs with all fields
         assoc_kwargs = {
-            "id": entity_id(),
             "subject": subject_id,
             "predicate": predicate,
             "object": object_id,

--- a/src/translator_ingest/ingests/ttd/ttd.py
+++ b/src/translator_ingest/ingests/ttd/ttd.py
@@ -3,7 +3,7 @@ import koza
 import pandas as pd
 from typing import Any, Iterable, Dict, Union
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id
+
 from translator_ingest.util.biolink import INFORES_TTD
 from translator_ingest.util.http_utils import get_modify_date
 from biolink_model.datamodel.pydanticmodel_v2 import (
@@ -384,7 +384,6 @@ def p1_05_transform(koza: koza.KozaTransform, record: dict[str, Any]) -> Knowled
     chemical = ChemicalEntity(id=record["subject_pubchem"])
     indication = DiseaseOrPhenotypicFeature(id=record["object_nameres_id"])
     association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
-        id=entity_id(),
         subject=chemical.id,
         predicate=record["biolink_predicate"],
         object=indication.id,
@@ -608,7 +607,6 @@ def p1_07_transform(koza: koza.KozaTransform, record: dict[str, Any]) -> Knowled
     ## covers "interacts_with" and descendants with substring
     ## ASSUMING no special logic, so only 1 edge made
         association = ChemicalGeneInteractionAssociation(
-            id=entity_id(),
             subject=chemical.id,
             object=protein.id,
             knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
@@ -623,7 +621,6 @@ def p1_07_transform(koza: koza.KozaTransform, record: dict[str, Any]) -> Knowled
     ## currently covers all other cases
         ## MAIN EDGE
         association = ChemicalAffectsGeneAssociation(
-            id=entity_id(),
             subject=chemical.id,
             object=protein.id,
             knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
@@ -638,7 +635,6 @@ def p1_07_transform(koza: koza.KozaTransform, record: dict[str, Any]) -> Knowled
             ## SPECIAL logic: create extra "physical interaction" edge for some "affects" edges
             ## should be identical to original edge, except predicate/no qualifiers
             extra_assoc = ChemicalGeneInteractionAssociation(
-                id=entity_id(),
                 subject=chemical.id,
                 object=protein.id,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,

--- a/src/translator_ingest/ingests/ubergraph/ubergraph.py
+++ b/src/translator_ingest/ingests/ubergraph/ubergraph.py
@@ -14,7 +14,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     AgentTypeEnum,
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources
 
 INFORES_UBERGRAPH = "infores:ubergraph"
 
@@ -238,7 +238,6 @@ def transform_redundant_graph(koza: koza.KozaTransform, data: Iterable[dict[str,
             nodes_seen.add(object_curie)
         
         edges_batch.append(Association(
-            id=entity_id(),
             subject=subject_curie,
             predicate=predicate_curie,
             object=object_curie,

--- a/src/translator_ingest/pipeline.py
+++ b/src/translator_ingest/pipeline.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from importlib import import_module
 from pathlib import Path
 
+import translator_ingest.util.association_id  # noqa: F401 — triggers singleton config
 from translator_ingest.util.biolink import get_current_biolink_version
 from translator_ingest.util.logging_utils import get_logger, setup_logging
 

--- a/src/translator_ingest/util/association_id.py
+++ b/src/translator_ingest/util/association_id.py
@@ -1,0 +1,39 @@
+"""
+Centralized configuration for deterministic Association ID generation.
+
+The configuration is applied once at module import time. Any code that
+imports from this module (or imports a module that does) gets the
+configured strategy automatically — whether invoked via pipeline.py,
+Koza directly, or in tests.
+"""
+from biolink_model.datamodel.pydanticmodel_v2 import AssociationIdConfig, IdStrategy
+
+_association_id_strategy_configured = False
+
+
+def configure_association_ids(
+    strategy: IdStrategy = IdStrategy.ALL_FIELDS,
+    custom_fields: list[str] | None = None,
+    force: bool = False,
+) -> None:
+    """Configure how Association IDs are generated across all ingests.
+
+    Safe to call multiple times — only the first call takes effect
+    unless force=True.
+
+    Args:
+        strategy: The ID strategy to use. Defaults to ALL_FIELDS.
+        custom_fields: Field names for CUSTOM strategy only.
+        force: If True, reconfigure even if already configured (for testing).
+    """
+    global _association_id_strategy_configured
+    if _association_id_strategy_configured and not force:
+        return
+    AssociationIdConfig.strategy = strategy
+    if custom_fields is not None:
+        AssociationIdConfig.custom_fields = custom_fields
+    _association_id_strategy_configured = True
+
+
+# Apply default configuration on first import
+configure_association_ids()

--- a/tests/test_association_ids.py
+++ b/tests/test_association_ids.py
@@ -1,0 +1,151 @@
+"""Tests for centralized deterministic Association ID generation."""
+import pytest
+
+from biolink_model.datamodel.pydanticmodel_v2 import (
+    Association,
+    AssociationIdConfig,
+    ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation,
+    IdStrategy,
+    KnowledgeLevelEnum,
+    AgentTypeEnum,
+)
+
+import translator_ingest.util.association_id as assoc_id_module
+from translator_ingest.util.association_id import configure_association_ids
+
+
+@pytest.fixture(autouse=True)
+def _reset_id_config():
+    """Reset AssociationIdConfig and singleton flag after each test."""
+    original_strategy = AssociationIdConfig.strategy
+    original_fields = AssociationIdConfig.custom_fields
+    original_configured = assoc_id_module._association_id_strategy_configured
+    yield
+    AssociationIdConfig.strategy = original_strategy
+    AssociationIdConfig.custom_fields = original_fields
+    assoc_id_module._association_id_strategy_configured = original_configured
+
+
+def test_auto_configure_on_import():
+    """Importing the module auto-configures ALL_FIELDS strategy."""
+    assert assoc_id_module._association_id_strategy_configured is True
+    assert AssociationIdConfig.strategy == IdStrategy.ALL_FIELDS
+
+
+def test_configure_sets_all_fields_strategy():
+    """configure_association_ids() sets the ALL_FIELDS strategy by default."""
+    configure_association_ids(force=True)
+    assert AssociationIdConfig.strategy == IdStrategy.ALL_FIELDS
+
+
+def test_configure_is_idempotent():
+    """Second call without force=True is a no-op."""
+    configure_association_ids(force=True)
+    assert AssociationIdConfig.strategy == IdStrategy.ALL_FIELDS
+    # Try to change strategy without force — should be ignored
+    configure_association_ids(strategy=IdStrategy.CUSTOM, custom_fields=["subject"])
+    assert AssociationIdConfig.strategy == IdStrategy.ALL_FIELDS
+
+
+def test_configure_sets_custom_strategy_with_fields():
+    """configure_association_ids() can set a CUSTOM strategy with specific fields."""
+    configure_association_ids(
+        strategy=IdStrategy.CUSTOM,
+        custom_fields=["subject", "predicate", "object"],
+        force=True,
+    )
+    assert AssociationIdConfig.strategy == IdStrategy.CUSTOM
+    assert AssociationIdConfig.custom_fields == ["subject", "predicate", "object"]
+
+
+def test_deterministic_id_generated_without_explicit_id():
+    """Associations without explicit id get a deterministic uuid: prefixed ID."""
+    assoc = Association(
+        subject="HGNC:1",
+        predicate="biolink:related_to",
+        object="MONDO:0001",
+        knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+        agent_type=AgentTypeEnum.manual_agent,
+    )
+    assert assoc.id.startswith("uuid:")
+
+
+def test_same_inputs_produce_same_id():
+    """Identical inputs produce the same deterministic ID."""
+    kwargs = dict(
+        subject="HGNC:1",
+        predicate="biolink:related_to",
+        object="MONDO:0001",
+        knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+        agent_type=AgentTypeEnum.manual_agent,
+    )
+    a = Association(**kwargs)
+    b = Association(**kwargs)
+    assert a.id == b.id
+
+
+def test_different_inputs_produce_different_ids():
+    """Different inputs produce different deterministic IDs."""
+    common = dict(
+        predicate="biolink:related_to",
+        object="MONDO:0001",
+        knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+        agent_type=AgentTypeEnum.manual_agent,
+    )
+    a = Association(subject="HGNC:1", **common)
+    b = Association(subject="HGNC:2", **common)
+    assert a.id != b.id
+
+
+def test_explicit_id_preserved():
+    """An explicit id is preserved and not overwritten."""
+    assoc = Association(
+        id="my-explicit-id",
+        subject="HGNC:1",
+        predicate="biolink:related_to",
+        object="MONDO:0001",
+        knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+        agent_type=AgentTypeEnum.manual_agent,
+    )
+    assert assoc.id == "my-explicit-id"
+
+
+def test_deterministic_id_on_association_subclass():
+    """Deterministic IDs work on Association subclasses too."""
+    assoc = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
+        subject="CHEBI:1234",
+        predicate="biolink:treats",
+        object="MONDO:0001",
+        knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+        agent_type=AgentTypeEnum.manual_agent,
+    )
+    assert assoc.id.startswith("uuid:")
+
+
+@pytest.mark.parametrize(
+    "subject,object_id",
+    [
+        ("HGNC:1", "MONDO:0001"),
+        ("HGNC:2", "MONDO:0002"),
+        ("CHEBI:123", "HP:0001"),
+    ],
+)
+def test_deterministic_ids_vary_by_content(subject, object_id):
+    """Each unique subject/object combination gets a unique deterministic ID."""
+    assoc = Association(
+        subject=subject,
+        predicate="biolink:related_to",
+        object=object_id,
+        knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+        agent_type=AgentTypeEnum.manual_agent,
+    )
+    assert assoc.id.startswith("uuid:")
+    # Re-create to confirm determinism
+    assoc2 = Association(
+        subject=subject,
+        predicate="biolink:related_to",
+        object=object_id,
+        knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+        agent_type=AgentTypeEnum.manual_agent,
+    )
+    assert assoc.id == assoc2.id

--- a/tests/unit/ingests/hpoa/test_hpoa.py
+++ b/tests/unit/ingests/hpoa/test_hpoa.py
@@ -356,7 +356,7 @@ def test_predicate(association: str, expected_predicate: Optional[str]):
             {
                 "category": ["biolink:CorrelatedGeneToDiseaseAssociation"],
                 "subject": "NCBIGene:6505",
-                "predicate": "biolink:associated_with",
+                "predicate": "biolink:correlated_with",
                 "object": "OMIM:615232",
                 "qualified_predicate": "biolink:contributes_to",
                 "subject_form_or_variant_qualifier": "genetic_variant_form",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -166,8 +166,8 @@ wheels = [
 
 [[package]]
 name = "biolink-model"
-version = "4.3.6.post81.dev0+5f644a9b4"
-source = { git = "https://github.com/biolink/biolink-model.git?rev=master#5f644a9b42f7540dee4f894923a955553700b94a" }
+version = "4.3.6.post108.dev0+64711f39e"
+source = { git = "https://github.com/biolink/biolink-model.git?rev=issue-1707-deterministic-association-ids#64711f39e023efd7389311f95b32f049b129512d" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "click" },
@@ -309,7 +309,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.2" },
-    { name = "biolink-model", git = "https://github.com/biolink/biolink-model.git?rev=master" },
+    { name = "biolink-model", git = "https://github.com/biolink/biolink-model.git?rev=issue-1707-deterministic-association-ids" },
     { name = "bmt", git = "https://github.com/biolink/biolink-model-toolkit.git?rev=master" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "codespell", specifier = ">=2.4.1" },
@@ -331,7 +331,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "biolink-model", git = "https://github.com/biolink/biolink-model.git?rev=master" },
+    { name = "biolink-model", git = "https://github.com/biolink/biolink-model.git?rev=issue-1707-deterministic-association-ids" },
     { name = "black", specifier = ">=24.1.0" },
     { name = "codespell", specifier = ">=2.2.0" },
     { name = "jsonlines" },


### PR DESCRIPTION
## Summary
- Replace random UUID generation for association edge IDs with deterministic, content-based SHA-256 hashing using biolink-model's `AssociationIdConfig`
- All 29 ingests updated: callers no longer pass `id=` when constructing associations
- Singleton auto-configure pattern ensures consistent ID strategy whether invoked via pipeline.py, Koza directly, or in tests

## Details

See `pr-description.md` in the branch for the full architecture writeup, including:
- How the singleton pattern works
- The three ingest change patterns (entity_id, uuid4, source ID passthrough)
- What was intentionally NOT changed (RetrievalSource, Study objects)
- Biolink-model compatibility fixes (semmeddb, hpoa)

## Test plan
- [x] `tests/test_association_ids.py` — 12 tests covering singleton config, determinism, idempotency, subclasses
- [x] Full test suite passes (330 passed, 5 skipped)
- [x] Import-only auto-config verified without pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)