### PR TITLE
fixing up the mock on_begin function

### DIFF
--- a/tests/unit/ingests/gene2phenotype/test_g2p.py
+++ b/tests/unit/ingests/gene2phenotype/test_g2p.py
@@ -1,6 +1,6 @@
 import pytest
 
-# import koza    ## for mocking on_data_begin
+from koza.transform import KozaTransform
 from koza.runner import KozaRunner, KozaTransformHooks
 from tests.unit.ingests import MockKozaWriter
 
@@ -13,26 +13,21 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     RetrievalSource,
 )
 import datetime
-from translator_ingest.ingests.gene2phenotype.gene2phenotype import on_begin, transform
+from translator_ingest.ingests.gene2phenotype.gene2phenotype import transform
 
 
-## trying to mock on_data_begin, create koza.state["allelicreq_mappings"] in hard-coded manner.
-## but having trouble getting it to work
-# @pytest.fixture
-# def mock_on_begin():
-#     koza = koza.KozaTransform()
-#     koza.state["allelicreq_mappings"] = {
-#         "biallelic_autosomal": "HP:0000007",
-#         "monoallelic_autosomal": "HP:0000006",
-#         "biallelic_PAR": "HP:0034341",
-#         "monoallelic_PAR": "HP:0034340",
-#         "mitochondrial": "HP:0001427",
-#         "monoallelic_Y_hemizygous": "HP:0001450",
-#         "monoallelic_X": "HP:0001417",
-#         "monoallelic_X_hemizygous": "HP:0001419",
-#         "monoallelic_X_heterozygous": "HP:0001423"
-#     }
-#     return koza.state["allelicreq_mappings"]
+def mock_on_begin(koza: KozaTransform):
+    koza.transform_metadata["allelicreq_mappings"] = {
+        "biallelic_autosomal": "HP:0000007",
+        "monoallelic_autosomal": "HP:0000006",
+        "biallelic_PAR": "HP:0034341",
+        "monoallelic_PAR": "HP:0034340",
+        "mitochondrial": "HP:0001427",
+        "monoallelic_Y_hemizygous": "HP:0001450",
+        "monoallelic_X": "HP:0001417",
+        "monoallelic_X_hemizygous": "HP:0001419",
+        "monoallelic_X_heterozygous": "HP:0001423"
+    }
 
 
 @pytest.fixture
@@ -54,7 +49,7 @@ def single_record_test():
     ]
     ## running on_begin is problematic because it actually runs requests to retrieve outside data
     runner = KozaRunner(
-        data=records, writer=writer, hooks=KozaTransformHooks(on_data_begin=[on_begin], transform_record=[transform])
+        data=records, writer=writer, hooks=KozaTransformHooks(on_data_begin=[mock_on_begin], transform_record=[transform])
     )
     runner.run()
     return writer.items


### PR DESCRIPTION
Made this mock on_begin work. 

You were really close, just needed to have the koza instance in the mock on_begin be the one passed to the function by the koza runner instead of instantiating a new one.