### PR TITLE
Multisource KG Functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ ifeq ($(origin SOURCES), undefined)
 SOURCES := $(shell $(RUN) python -m translator_ingest.graphs sources $(GRAPH_ID))
 endif
 
-NODE_PROPERTIES ?= ncbi_gene
+# Sources that only produce nodes. Derived from configuration in ingests/{source}/{source}.yaml.
+NODES_ONLY_SOURCES := $(shell $(RUN) python -m translator_ingest.ingest_config nodes-only $(SOURCES))
 
 # Set to any non-empty value to overwrite previously generated files
 OVERWRITE ?=
@@ -204,7 +205,7 @@ merge-all:
 
 .PHONY: release
 release:
-	@$(MAKE) -j $(words $(filter-out $(NODE_PROPERTIES),$(SOURCES))) $(addprefix release-,$(filter-out $(NODE_PROPERTIES),$(SOURCES)))
+	@$(MAKE) -j $(words $(filter-out $(NODES_ONLY_SOURCES),$(SOURCES))) $(addprefix release-,$(filter-out $(NODES_ONLY_SOURCES),$(SOURCES)))
 	@$(RUN) python src/translator_ingest/release.py --summary
 
 .PHONY: release-%

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,16 @@
 ROOTDIR = $(shell pwd)
 RUN = uv run
-# Configure which sources to process (default: all available sources)
-# Allow lowercase 'sources' as an alias for SOURCES
+
+# Graph ID for multisource graph target (default: translator_kg).
+# Graph definitions live in graphs.yaml; see src/translator_ingest/graphs.py.
+GRAPH_ID ?= translator_kg
+
+# Configure which sources to process. If SOURCES is not set, resolve it from graphs.yaml using GRAPH_ID.
 ifdef sources
 SOURCES := $(sources)
-else
-SOURCES ?= alliance bgee bindingdb chembl cohd ctd ctkp dakp dgidb diseases drug_rep_hub drugcentral gtopdb gene2phenotype geneticskp go_cam goa hpoa icees intact ncbi_gene panther pathbank semmeddb sider signor tmkp ttd ubergraph
+endif
+ifeq ($(origin SOURCES), undefined)
+SOURCES := $(shell $(RUN) python -m translator_ingest.graphs sources $(GRAPH_ID))
 endif
 
 NODE_PROPERTIES ?= ncbi_gene
@@ -28,9 +33,6 @@ endif
 # (3) acronyms and external vocabulary tokens in analysis cells add more noise.
 # Prefer spell-checking .py, .yaml, and prose docs instead.
 CODESPELL_SKIP := ./data/*,**/site-packages,**/*.ipynb
-
-# Graph ID for merge target (default: translator_kg)
-GRAPH_ID ?= translator_kg
 
 # Include additional makefiles
 include rig.Makefile
@@ -64,6 +66,7 @@ define HELP
 │     validate-single     Validate only specified sources                      │
 │     release             Generate releases for the specified sources          │
 │     merge               Merge specified sources into one KG                  │
+│     merge-all           Merge every graph declared in graphs.yaml            │
 │                                                                              │
 │     test                Run all tests                                        │
 │                                                                              │
@@ -85,10 +88,10 @@ define HELP
 │     docs-clean          Clean documentation build                            │
 │                                                                              │
 │ Configuration:                                                               │
-│     SOURCES             Space-separated list of sources                      │
-│                         Default: all available sources                       │
-│     GRAPH_ID            Graph ID for merged graphs                           │
+│     GRAPH_ID            Graph ID for multisource graphs (see graphs.yaml)    │
 │                         Default: translator_kg                               │
+│     SOURCES             Space-separated list of sources                      │
+│                         Default: resolved from graphs.yaml using GRAPH_ID    │
 │                                                                              │
 │ Examples:                                                                    │
 │     # Run pipeline for all sources                                           │
@@ -106,10 +109,14 @@ define HELP
 │     # Make releases only for specified sources                               │
 │     make release SOURCES="ctd go_cam goa"                                    │
 │                                                                              │
-│     # Merge all sources into one graph named translator_kg                   │
+│     # Build and release the default multisource KG (translator_kg)           │
 │     make merge                                                               │
-│     # Merge specified sources into a graph named example_custom_graph        │
-│     make merge GRAPH_ID=example_custom_graph SOURCES="ctd go_cam goa"        │
+│     # Build and release the KG translator_kg_open (declared in graphs.yaml)  │
+│     make merge GRAPH_ID=translator_kg_open                                   │
+│     # Build and release every KG declared in graphs.yaml                     │
+│     make merge-all                                                           │
+│     # Build and release a custom KG that is not defined in graphs.yaml       │
+│     make merge GRAPH_ID=example_custom_kg SOURCES="ctd go_cam goa"           │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 endef
 export HELP
@@ -186,6 +193,14 @@ validate-%:
 merge:
 	@echo "Merging sources and building $(GRAPH_ID)..."
 	$(RUN) python src/translator_ingest/merging.py $(GRAPH_ID) $(SOURCES) $(if $(OVERWRITE),--overwrite)
+
+.PHONY: merge-all
+merge-all:
+	@for gid in $$($(RUN) python -m translator_ingest.graphs list); do \
+		echo "Building graph: $$gid..."; \
+		srcs=$$($(RUN) python -m translator_ingest.graphs sources $$gid) || exit $$?; \
+		$(RUN) python src/translator_ingest/merging.py $$gid $$srcs $(if $(OVERWRITE),--overwrite) || exit $$?; \
+	done
 
 .PHONY: release
 release:

--- a/graphs.yaml
+++ b/graphs.yaml
@@ -1,0 +1,59 @@
+---
+# Declarative list of multi-source knowledge graphs.
+#
+# Each entry must have a unique `graph_id` and either:
+#   - `sources`: an explicit list of source ingest names, OR
+#   - `base`: another graph_id to inherit sources from (may then be adjusted
+#             with `includes` and/or `excludes`).
+#
+# `includes` and `excludes` are only valid when `base` is set.
+#
+# Resolution is:  start = base_sources or sources
+#                 result = (start - excludes) | includes
+#
+# Adding a new source to translator_kg is an explicit change: add the source
+# name to the `sources` list below.
+
+graphs:
+  - graph_id: translator_kg  # Our main multisource KG used for Translator Tier 0
+    sources:
+      - alliance
+      - bgee
+      - bindingdb
+      - chembl
+      - cohd
+      - ctd
+      - ctkp
+      - dakp
+      - dgidb
+      - diseases
+      - drug_rep_hub
+      - drugcentral
+      - gene2phenotype
+      - geneticskp
+      - go_cam
+      - goa
+      - gtopdb
+      - hpoa
+      - icees
+      - intact
+      - ncbi_gene
+      - panther
+      - pathbank
+      - semmeddb
+      - sider
+      - signor
+      - tmkp
+      - ttd
+      - ubergraph
+
+  - graph_id: translator_kg_open  # A version of translator_kg excluding sources with restrictive licenses
+    base: translator_kg
+    excludes:
+      - ctd
+      - dgidb
+      - hpoa
+      - tmkp
+      - pathbank
+      - semmeddb
+      - ttd   # provisional, remove if determined open

--- a/src/translator_ingest/graphs.py
+++ b/src/translator_ingest/graphs.py
@@ -1,0 +1,148 @@
+"""Resolver for multi-source knowledge-graph definitions declared in graphs.yaml.
+
+A graph entry has a ``graph_id`` and either an explicit ``sources`` list or a
+``base`` reference to another graph (optionally adjusted with ``includes`` and
+``excludes``).  Resolution flattens ``base`` chains, applies excludes, then
+applies includes, returning a source list.
+
+CLI ::
+
+    get the list of all available graph ids
+    uv run python -m translator_ingest.graphs list
+    
+    get the list of sources for a particular graph_id
+    uv run python -m translator_ingest.graphs sources <graph_id>
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+import yaml
+
+
+DEFAULT_GRAPHS_YAML = Path(__file__).resolve().parents[2] / "graphs.yaml"
+
+
+class GraphConfigError(ValueError):
+    """Raised when graphs.yaml is malformed or a graph_id cannot be resolved."""
+
+
+def load_graphs(path: Path = DEFAULT_GRAPHS_YAML) -> dict[str, dict[str, Any]]:
+    """Load graphs.yaml and return a ``{graph_id: entry}`` mapping.
+
+    Validates structural invariants:
+      - Top-level ``graphs`` must be a list.
+      - Each entry must have a ``graph_id``.
+      - ``graph_id`` must be unique.
+      - An entry must declare exactly one of ``sources`` or ``base``.
+      - ``includes`` / ``excludes`` require ``base``.
+
+    Raises:
+        GraphConfigError: if the file is missing or malformed.
+    """
+    if not path.exists():
+        raise GraphConfigError(f"graphs.yaml not found at {path}")
+
+    with path.open() as f:
+        data = yaml.safe_load(f) or {}
+
+    entries = data.get("graphs")
+    if not isinstance(entries, list):
+        raise GraphConfigError("graphs.yaml must have a top-level 'graphs:' list")
+
+    by_id: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise GraphConfigError(f"Each graphs entry must be a mapping, got: {entry!r}")
+
+        graph_id = entry.get("graph_id")
+        if not graph_id or not isinstance(graph_id, str):
+            raise GraphConfigError(f"Entry missing string 'graph_id': {entry!r}")
+
+        if graph_id in by_id:
+            raise GraphConfigError(f"Duplicate graph_id: {graph_id}")
+
+        has_sources = "sources" in entry
+        has_base = "base" in entry
+        if has_sources == has_base:
+            raise GraphConfigError(
+                f"Graph {graph_id!r} must declare exactly one of 'sources' or 'base'"
+            )
+
+        if ("includes" in entry or "excludes" in entry) and not has_base:
+            raise GraphConfigError(
+                f"Graph {graph_id!r}: 'includes'/'excludes' require 'base'"
+            )
+
+        by_id[graph_id] = entry
+
+    return by_id
+
+
+def _resolve(
+    graph_id: str,
+    by_id: dict[str, dict[str, Any]],
+    _visiting: frozenset[str] = frozenset(),
+) -> list[str]:
+    """Resolve a graph_id into its sorted list of source names."""
+    if graph_id not in by_id:
+        raise GraphConfigError(f"Unknown graph_id: {graph_id!r}")
+    if graph_id in _visiting:
+        chain = " -> ".join([*_visiting, graph_id])
+        raise GraphConfigError(f"Circular 'base' reference: {chain}")
+
+    entry = by_id[graph_id]
+
+    if "sources" in entry:
+        sources = set(entry["sources"])
+    else:
+        sources = set(_resolve(entry["base"], by_id, _visiting | {graph_id}))
+
+    sources -= set(entry.get("excludes") or [])
+    sources |= set(entry.get("includes") or [])
+    return sorted(sources)
+
+
+def resolve_sources(graph_id: str, path: Path = DEFAULT_GRAPHS_YAML) -> list[str]:
+    """Return the resolved, sorted list of sources for ``graph_id``."""
+    return _resolve(graph_id, load_graphs(path))
+
+
+def list_graph_ids(path: Path = DEFAULT_GRAPHS_YAML) -> list[str]:
+    """Return all declared graph_ids in declaration order."""
+    return list(load_graphs(path).keys())
+
+
+@click.group()
+def cli() -> None:
+    """Inspect graph definitions declared in graphs.yaml."""
+
+
+@cli.command("list")
+@click.option("--path", type=click.Path(path_type=Path), default=DEFAULT_GRAPHS_YAML,
+              help="Path to graphs.yaml")
+def _list(path: Path) -> None:
+    """Print all declared graph_ids, one per line."""
+    for gid in list_graph_ids(path):
+        click.echo(gid)
+
+
+@cli.command("sources")
+@click.argument("graph_id")
+@click.option("--path", type=click.Path(path_type=Path), default=DEFAULT_GRAPHS_YAML,
+              help="Path to graphs.yaml")
+def _sources(graph_id: str, path: Path) -> None:
+    """Print the space-separated list of sources for GRAPH_ID."""
+    try:
+        click.echo(" ".join(resolve_sources(graph_id, path)))
+    except GraphConfigError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    cli()

--- a/src/translator_ingest/ingest_config.py
+++ b/src/translator_ingest/ingest_config.py
@@ -1,0 +1,86 @@
+"""Ingest-level metadata helpers that read ``ingests/{source}/{source}.yaml``.
+
+Used by Makefile targets and build tooling that need to introspect koza
+configuration *without* spinning up the full pipeline. The only reader in
+this module is ``yaml.safe_load`` — we deliberately mirror the schema
+rather than instantiating koza's config parser so these helpers stay cheap
+to call for every source during a ``make`` invocation.
+
+CLI (used by the Makefile)::
+
+    uv run python -m translator_ingest.ingest_config nodes-only ctd go_cam ncbi_gene
+"""
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import click
+import yaml
+
+from translator_ingest import INGESTS_PARSER_PATH
+
+
+def _ingest_yaml_path(source: str, ingests_dir: Path = INGESTS_PARSER_PATH) -> Path:
+    """Location of the koza config yaml for ``source``."""
+    return Path(ingests_dir) / source / f"{source}.yaml"
+
+
+def is_nodes_only_source(source: str, ingests_dir: Path = INGESTS_PARSER_PATH) -> bool:
+    """Return True if ``source`` is a nodes-only ingest.
+
+    A source is nodes-only when its koza config has ``writer.max_edge_count: 0``.
+    This matches what ``pipeline.load_koza_config`` reads into
+    ``pipeline_metadata.koza_config['max_edge_count']``.
+
+    Missing yaml, missing ``writer`` block, or a non-zero ``max_edge_count``
+    all return False.
+
+    Examples:
+        >>> # ncbi_gene.yaml has `writer.max_edge_count: 0`
+        >>> is_nodes_only_source("ncbi_gene")
+        True
+        >>> is_nodes_only_source("go_cam")
+        False
+    """
+    path = _ingest_yaml_path(source, ingests_dir)
+    if not path.exists():
+        return False
+    with path.open() as f:
+        config = yaml.safe_load(f) or {}
+    writer = config.get("writer") or {}
+    return writer.get("max_edge_count") == 0
+
+
+def get_nodes_only_sources(
+    sources: Iterable[str],
+    ingests_dir: Path = INGESTS_PARSER_PATH,
+) -> list[str]:
+    """Return the subset of ``sources`` that are nodes-only ingests.
+
+    Order is preserved to mirror the caller's list (Makefile ``$(SOURCES)``).
+
+    Examples:
+        >>> get_nodes_only_sources(["ctd", "ncbi_gene", "go_cam"])
+        ['ncbi_gene']
+    """
+    return [s for s in sources if is_nodes_only_source(s, ingests_dir)]
+
+
+@click.group()
+def cli() -> None:
+    """Inspect ingest-level koza configuration."""
+
+
+@cli.command("nodes-only")
+@click.argument("sources", nargs=-1)
+def _nodes_only(sources: tuple[str, ...]) -> None:
+    """Print the subset of nodes-only SOURCES``.
+
+    Output is a space-separated list on a single line, suitable for Make's
+    ``$(shell ...)``. Prints nothing (exit 0) when no sources qualify.
+    """
+    click.echo(" ".join(get_nodes_only_sources(sources)))
+
+
+if __name__ == "__main__":
+    cli()

--- a/src/translator_ingest/ingests/semmeddb/metadata.yaml
+++ b/src/translator_ingest/ingests/semmeddb/metadata.yaml
@@ -1,3 +1,0 @@
-ingest_title: 'SemMedDB'
-description: 'Literature-derived semantic predications extracted by SemRep from PubMed'
-rights: 'https://lhncbc.nlm.nih.gov/temp/SemRep_SemMedDB_SKR/dbinfo.html'

--- a/src/translator_ingest/ingests/semmeddb/semmeddb.yaml
+++ b/src/translator_ingest/ingests/semmeddb/semmeddb.yaml
@@ -1,5 +1,8 @@
 name: semmeddb
-metadata: !include './metadata.yaml'
+metadata:
+  ingest_title: 'SemMedDB'
+  description: 'Literature-derived semantic predications extracted by SemRep from PubMed'
+  rights: 'https://lhncbc.nlm.nih.gov/temp/SemRep_SemMedDB_SKR/dbinfo.html'
 
 readers:
   filter_edges:

--- a/src/translator_ingest/merging.py
+++ b/src/translator_ingest/merging.py
@@ -354,12 +354,46 @@ def merge_graph_metadata(pipeline_metadata: PipelineMetadata, kgx_sources: list[
 
 
 
+def _warn_if_sources_diverge_from_declaration(graph_id: str, sources: list[str]) -> None:
+    """Warn when ``graph_id`` is declared in graphs.yaml but sources don't match.
+
+    Protects against ``make merge GRAPH_ID=translator_kg_open SOURCES="ctd"``
+    silently producing a build labeled ``translator_kg_open`` whose contents
+    contradict the yaml declaration. Missing or unreadable graphs.yaml is
+    non-fatal — ad-hoc graph_ids remain allowed.
+    """
+    try:
+        # Imported lazily so merging.py has no hard dependency on graphs.yaml
+        # for ad-hoc graph_ids that aren't declared there.
+        from translator_ingest.graphs import GraphConfigError, resolve_sources
+    except ImportError:
+        return
+
+    try:
+        declared = resolve_sources(graph_id)
+    except GraphConfigError:
+        return  # graph_id is not declared; ad-hoc builds are fine
+
+    if set(declared) != set(sources):
+        extra = sorted(set(sources) - set(declared))
+        missing = sorted(set(declared) - set(sources))
+        logger.warning(
+            "!!! Sources passed on the command line do not match the graphs.yaml "
+            "declaration for %r. Proceeding anyway, but the resulting build "
+            "will be labeled %r despite not matching its declared source set. "
+            "Extra: %s. Missing: %s. !!!",
+            graph_id, graph_id, extra or "(none)", missing or "(none)",
+        )
+
+
 @click.command()
 @click.argument("graph_id", required=True)
 @click.argument("sources", nargs=-1, required=True)
 @click.option("--overwrite", is_flag=True, help="Start fresh and overwrite previously generated files.")
 def main(graph_id, sources, overwrite):
     setup_logging()
+
+    _warn_if_sources_diverge_from_declaration(graph_id, list(sources))
 
     # Merge the sources into one KGX and generate metadata
     merged_graph_metadata, kgx_sources = merge(

--- a/tests/unit/test_graphs.py
+++ b/tests/unit/test_graphs.py
@@ -1,0 +1,149 @@
+"""Tests for the graphs.yaml resolver."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from translator_ingest.graphs import (
+    DEFAULT_GRAPHS_YAML,
+    GraphConfigError,
+    list_graph_ids,
+    load_graphs,
+    resolve_sources,
+)
+
+
+def _write_yaml(path: Path, data: dict) -> Path:
+    path.write_text(yaml.safe_dump(data))
+    return path
+
+
+@pytest.fixture
+def graphs_file(tmp_path):
+    def _make(entries):
+        return _write_yaml(tmp_path / "graphs.yaml", {"graphs": entries})
+    return _make
+
+
+# ── resolution ────────────────────────────────────────────────────────────────
+
+def test_sources_only_returns_sorted_list(graphs_file):
+    path = graphs_file([{"graph_id": "g", "sources": ["c", "a", "b"]}])
+    assert resolve_sources("g", path) == ["a", "b", "c"]
+
+
+def test_base_inherits_sources(graphs_file):
+    path = graphs_file([
+        {"graph_id": "parent", "sources": ["a", "b", "c"]},
+        {"graph_id": "child", "base": "parent"},
+    ])
+    assert resolve_sources("child", path) == ["a", "b", "c"]
+
+
+def test_excludes_removes_from_base(graphs_file):
+    path = graphs_file([
+        {"graph_id": "parent", "sources": ["a", "b", "c"]},
+        {"graph_id": "child", "base": "parent", "excludes": ["b"]},
+    ])
+    assert resolve_sources("child", path) == ["a", "c"]
+
+
+def test_includes_adds_to_base(graphs_file):
+    path = graphs_file([
+        {"graph_id": "parent", "sources": ["a", "b"]},
+        {"graph_id": "child", "base": "parent", "includes": ["c"]},
+    ])
+    assert resolve_sources("child", path) == ["a", "b", "c"]
+
+
+def test_excludes_then_includes(graphs_file):
+    # Includes should win over excludes when a name appears in both.
+    path = graphs_file([
+        {"graph_id": "parent", "sources": ["a", "b", "c"]},
+        {"graph_id": "child", "base": "parent", "excludes": ["b"], "includes": ["b", "d"]},
+    ])
+    assert resolve_sources("child", path) == ["a", "b", "c", "d"]
+
+
+def test_multi_level_base(graphs_file):
+    path = graphs_file([
+        {"graph_id": "g1", "sources": ["a", "b", "c", "d"]},
+        {"graph_id": "g2", "base": "g1", "excludes": ["d"]},
+        {"graph_id": "g3", "base": "g2", "excludes": ["a"]},
+    ])
+    assert resolve_sources("g3", path) == ["b", "c"]
+
+
+# ── translator_kg_open against real graphs.yaml ──────────────────────────────
+
+def test_translator_kg_open_excludes_closed_sources():
+    resolved = resolve_sources("translator_kg_open", DEFAULT_GRAPHS_YAML)
+    parent = resolve_sources("translator_kg", DEFAULT_GRAPHS_YAML)
+    assert "ctd" in parent and "semmeddb" in parent
+    assert "ctd" not in resolved
+    assert "semmeddb" not in resolved
+
+
+def test_list_graph_ids_preserves_declaration_order():
+    ids = list_graph_ids(DEFAULT_GRAPHS_YAML)
+    assert ids[0] == "translator_kg"
+    assert "translator_kg_open" in ids
+
+
+# ── validation errors ────────────────────────────────────────────────────────
+
+def test_missing_graph_id_raises(graphs_file):
+    path = graphs_file([{"sources": ["a"]}])
+    with pytest.raises(GraphConfigError, match="graph_id"):
+        load_graphs(path)
+
+
+def test_duplicate_graph_id_raises(graphs_file):
+    path = graphs_file([
+        {"graph_id": "g", "sources": ["a"]},
+        {"graph_id": "g", "sources": ["b"]},
+    ])
+    with pytest.raises(GraphConfigError, match="Duplicate"):
+        load_graphs(path)
+
+
+def test_must_declare_sources_or_base(graphs_file):
+    path = graphs_file([{"graph_id": "g"}])
+    with pytest.raises(GraphConfigError, match="sources.*base"):
+        load_graphs(path)
+
+
+def test_cannot_declare_both_sources_and_base(graphs_file):
+    path = graphs_file([
+        {"graph_id": "parent", "sources": ["a"]},
+        {"graph_id": "g", "sources": ["a"], "base": "parent"},
+    ])
+    with pytest.raises(GraphConfigError, match="sources.*base"):
+        load_graphs(path)
+
+
+def test_includes_excludes_require_base(graphs_file):
+    path = graphs_file([{"graph_id": "g", "sources": ["a"], "excludes": ["a"]}])
+    with pytest.raises(GraphConfigError, match="require 'base'"):
+        load_graphs(path)
+
+
+def test_unknown_base_raises(graphs_file):
+    path = graphs_file([{"graph_id": "child", "base": "nope"}])
+    with pytest.raises(GraphConfigError, match="Unknown graph_id"):
+        resolve_sources("child", path)
+
+
+def test_cycle_detection(graphs_file):
+    path = graphs_file([
+        {"graph_id": "a", "base": "b"},
+        {"graph_id": "b", "base": "a"},
+    ])
+    with pytest.raises(GraphConfigError, match="Circular"):
+        resolve_sources("a", path)
+
+
+def test_missing_file_raises(tmp_path):
+    with pytest.raises(GraphConfigError, match="not found"):
+        load_graphs(tmp_path / "does-not-exist.yaml")

--- a/tests/unit/test_ingest_config.py
+++ b/tests/unit/test_ingest_config.py
@@ -1,0 +1,58 @@
+"""Tests for ingest_config.is_nodes_only_source / get_nodes_only_sources."""
+
+from pathlib import Path
+
+import pytest
+
+from translator_ingest.ingest_config import (
+    get_nodes_only_sources,
+    is_nodes_only_source,
+)
+
+
+def _write_yaml(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+@pytest.fixture
+def ingests_dir(tmp_path):
+    """Build a fake ingests/ tree with several sources for parametrized checks."""
+    _write_yaml(tmp_path / "nodes_only/nodes_only.yaml", "writer:\n  max_edge_count: 0\n")
+    _write_yaml(tmp_path / "has_edges/has_edges.yaml", "writer:\n  max_edge_count: 100\n")
+    _write_yaml(tmp_path / "no_writer/no_writer.yaml", "reader:\n  format: csv\n")
+    _write_yaml(tmp_path / "empty_writer/empty_writer.yaml", "writer:\n")
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("nodes_only", True),
+        ("has_edges", False),
+        ("no_writer", False),
+        ("empty_writer", False),
+        ("missing_source", False),
+    ],
+)
+def test_is_nodes_only_source(ingests_dir, source, expected):
+    assert is_nodes_only_source(source, ingests_dir) is expected
+
+
+def test_get_nodes_only_sources_filters_and_preserves_order(ingests_dir):
+    sources = ["has_edges", "nodes_only", "no_writer", "missing_source"]
+    assert get_nodes_only_sources(sources, ingests_dir) == ["nodes_only"]
+
+
+def test_get_nodes_only_sources_empty_input(ingests_dir):
+    assert get_nodes_only_sources([], ingests_dir) == []
+
+
+# ── Integration against the real repo ingests/ tree ──────────────────────────
+
+def test_ncbi_gene_is_nodes_only():
+    assert is_nodes_only_source("ncbi_gene") is True
+
+
+def test_known_edge_source_is_not_nodes_only():
+    assert is_nodes_only_source("go_cam") is False


### PR DESCRIPTION
This is a way for us to easily build two versions of translator_kg (tier 0), one without sources with restrictive licensing. I went ahead and improved how sources and multisource KGs are handled by the Makefile in general - no more hardcoding sources in the Makefile. We should fairly easily be able to incorporate this into Adil's new run_build work, to build both graphs whenever we do a full build.

**Graph Building**
- A new graph.yaml file defines an arbitrary number of graphs and the sources they should include.
- A parser/resolver (graphs.py) reads this and let's the Makefile reference graphs by id. It allows us to optionally specify for a graph a "base" graph it inherits it's core list of sources from and include/exclude lists which modify those sources.
- The list of sources used to build translator_kg is moved into this file, and a new graph, translator_kg_open, takes translator_kg as a base and excludes a list of sources deemed restrictive.
- By default Makefile SOURCES grabs the list of sources for the Makefile GRAPH_ID, which defaults to translator_kg, so same behavior as before when commands are run without specifying a GRAPH_ID or SOURCES, but can now specify any GRAPH_ID in graphs.yaml without having to declare sources.
- Added Makefile option merge-all that builds every graph in graphs.yaml

**Nodes-Only List**
- Before we had a hard-coded list of nodes only ingests in the Makefile. Implemented an automated way to determine that from the koza yaml so we don't need to maintain that.
- This just reads the koza yaml directly as yaml instead of validating it through koza, it's a bit brittle but I think that's better because it's faster and doesn't output logs etc. I kind of think we might want to revisit how we handle nodes only sources anyway.
- I had to move semmeddbs koza yaml !include of metadata into the koza yaml to enable a safe_load