### PR TITLE
Association ID Standardization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "psycopg[binary]",     # for Postgres querying, needed for specific ingest
     "polars>=1.35.2",
     "requests",    ## needed for specific ingest
-    "robokop-orion==1.3.2",
+    "robokop-orion==1.3.3",
     "uv-dynamic-versioning>=0.11.2",
     "xmltodict>=1.0.2",
     "zstandard>=0.25.0"

--- a/src/translator_ingest/ingests/_ingest_template/_ingest_template.py
+++ b/src/translator_ingest/ingests/_ingest_template/_ingest_template.py
@@ -26,6 +26,11 @@ from translator_ingest.util.biolink import INFORES_CTD
 # "ingest_all", and "transform_ingest_all_streaming". Tags should be declared as keys in the readers section of ingest
 # yaml files, then included with the (tag="tag_id") syntax as parameters in corresponding koza decorators.
 
+# It is good practice to generate the "sources" property for Associations (edges) just once if it will not vary from
+# edge to edge. You can use a constant like this, specific to your ingest, and apply it to edges (see usage below).
+# Here build_association_knowledge_sources is used, a helper function that properly instantiates "sources" with
+# RetrievalSource objects for simple use cases.
+INGEST_TEMPLATE_SOURCES = build_association_knowledge_sources(primary=INFORES_CTD)
 
 # Always implement a function that returns a string representing the latest version of the source data.
 # Ideally, this is the version provided by the knowledge source, directly associated with a specific data download.
@@ -111,7 +116,7 @@ def transform_ingest_by_record(koza: koza.KozaTransform, record: dict[str, Any])
         predicate="biolink:related_to",
         object=disease.id,
         publications=publications,
-        sources=build_association_knowledge_sources(primary=INFORES_CTD),
+        sources=INGEST_TEMPLATE_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
     )
@@ -134,7 +139,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
             subject=chemical.id,
             predicate="biolink:related_to",
             object=disease.id,
-            sources=build_association_knowledge_sources(primary=INFORES_CTD),
+            sources=INGEST_TEMPLATE_SOURCES,
             knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
             agent_type=AgentTypeEnum.manual_agent,
         )
@@ -157,7 +162,7 @@ def transform_ingest_all_streaming(
             subject=chemical.id,
             predicate="biolink:related_to",
             object=disease.id,
-            sources=build_association_knowledge_sources(primary=INFORES_CTD),
+            sources=INGEST_TEMPLATE_SOURCES,
             knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
             agent_type=AgentTypeEnum.manual_agent,
         )

--- a/src/translator_ingest/ingests/_ingest_template/_ingest_template.py
+++ b/src/translator_ingest/ingests/_ingest_template/_ingest_template.py
@@ -12,7 +12,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     Association,
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.biolink import INFORES_CTD
 
 # !!! README First !!!

--- a/src/translator_ingest/ingests/_ingest_template/_ingest_template.py
+++ b/src/translator_ingest/ingests/_ingest_template/_ingest_template.py
@@ -1,4 +1,3 @@
-import uuid
 import koza
 import pandas as pd
 from typing import Any, Iterable
@@ -130,11 +129,11 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
         chemical = ChemicalEntity(id="MESH:" + record["ChemicalID"], name=record["ChemicalName"])
         disease = Disease(id=record["DiseaseID"], name=record["DiseaseName"])
         association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
-            id=str(uuid.uuid4()),
+            id=entity_id(),
             subject=chemical.id,
             predicate="biolink:related_to",
             object=disease.id,
-            primary_knowledge_source=INFORES_CTD,
+            sources=build_association_knowledge_sources(primary=INFORES_CTD),
             knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
             agent_type=AgentTypeEnum.manual_agent,
         )
@@ -153,11 +152,11 @@ def transform_ingest_all_streaming(
         chemical = ChemicalEntity(id="MESH:" + record["ChemicalID"], name=record["ChemicalName"])
         disease = Disease(id=record["DiseaseID"], name=record["DiseaseName"])
         association = ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation(
-            id=str(uuid.uuid4()),
+            id=entity_id(),
             subject=chemical.id,
             predicate="biolink:related_to",
             object=disease.id,
-            primary_knowledge_source=INFORES_CTD,
+            sources=build_association_knowledge_sources(primary=INFORES_CTD),
             knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
             agent_type=AgentTypeEnum.manual_agent,
         )

--- a/src/translator_ingest/ingests/alliance/alliance.py
+++ b/src/translator_ingest/ingests/alliance/alliance.py
@@ -18,7 +18,8 @@ from koza.model.graphs import KnowledgeGraph
 from loguru import logger
 from pathlib import Path
 
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from biolink_model.datamodel.pydanticmodel_v2 import (
     Gene,
     GeneToPhenotypicFeatureAssociation,

--- a/src/translator_ingest/ingests/bgee/bgee.py
+++ b/src/translator_ingest/ingests/bgee/bgee.py
@@ -16,7 +16,8 @@ from translator_ingest.util.biolink import INFORES_BGEE
 
 from koza.model.graphs import KnowledgeGraph
 
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 
 BIOLINK_EXPRESSED_IN = "biolink:expressed_in"
 

--- a/src/translator_ingest/ingests/bgee/bgee.py
+++ b/src/translator_ingest/ingests/bgee/bgee.py
@@ -20,6 +20,7 @@ from translator_ingest.util.biolink import build_association_knowledge_sources
 from translator_ingest.util.transform_utils import entity_id
 
 BIOLINK_EXPRESSED_IN = "biolink:expressed_in"
+BGEE_SOURCES = build_association_knowledge_sources(primary=INFORES_BGEE)
 
 def get_latest_version() -> str:
     """Get version from the manifest file"""
@@ -81,7 +82,7 @@ def transform_bgee_expressed_in(
         subject=gene_id,
         predicate=BIOLINK_EXPRESSED_IN,
         object=anatomical_id,
-        sources=build_association_knowledge_sources(primary=INFORES_BGEE),
+        sources=BGEE_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.automated_agent,
     )

--- a/src/translator_ingest/ingests/bindingdb/bindingdb.py
+++ b/src/translator_ingest/ingests/bindingdb/bindingdb.py
@@ -12,7 +12,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     KnowledgeLevelEnum,
     AgentTypeEnum
 )
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from koza.model.graphs import KnowledgeGraph
 
 from translator_ingest.ingests.bindingdb.bindingdb_util import (

--- a/src/translator_ingest/ingests/bindingdb/bindingdb_util.py
+++ b/src/translator_ingest/ingests/bindingdb/bindingdb_util.py
@@ -13,7 +13,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     AffinityMeasurement,
     BinaryRelationEnum as bre
 )
-from bmt.pydantic import entity_id
+from translator_ingest.util.transform_utils import entity_id
 
 #
 # Core BindingDb Record Field Name Keys - currently ignored fields commented out

--- a/src/translator_ingest/ingests/chembl/chembl.py
+++ b/src/translator_ingest/ingests/chembl/chembl.py
@@ -18,7 +18,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
 
 from koza.model.graphs import KnowledgeGraph
 
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 
 from translator_ingest import INGESTS_PARSER_PATH
 

--- a/src/translator_ingest/ingests/chembl/chembl.py
+++ b/src/translator_ingest/ingests/chembl/chembl.py
@@ -28,6 +28,7 @@ QUALIFIER_CONFIG_PATH = INGESTS_PARSER_PATH / "chembl" / "chembl_qualifiers.json
 LATEST_VERSION = "36"
 
 INFORES_CHEMBL = "infores:chembl"
+CHEMBL_SOURCES = build_association_knowledge_sources(primary=INFORES_CHEMBL)
 
 MOA_QUERY = """
         SELECT
@@ -549,7 +550,7 @@ def get_association(koza, record, action_type_map):
                 object=target.id,
                 species_context_qualifier = species_context_qualifier,
                 object_form_or_variant_qualifier = mutation_qualifier,
-                sources=build_association_knowledge_sources(INFORES_CHEMBL),
+                sources=CHEMBL_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
                 publications=publications,
@@ -580,7 +581,7 @@ def get_activity_association(koza: koza.KozaTransform, chemical, target, action_
         object=target.id,
         species_context_qualifier = species_context_qualifier,
         anatomical_context_qualifier = [anatomical_context_qualifier] if anatomical_context_qualifier else None,
-        sources=build_association_knowledge_sources(INFORES_CHEMBL),
+        sources=CHEMBL_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.automated_agent if record["curated_by"] == "Autocuration" else AgentTypeEnum.manual_agent,
         publications=publications,
@@ -604,7 +605,7 @@ def create_chemical_association(koza: koza.KozaTransform, substrate, metabolite,
         object=metabolite.id,
         species_context_qualifier = species_context_qualifier,
         # TODO: context_qualifier = context_qualifier,
-        sources=build_association_knowledge_sources(INFORES_CHEMBL),
+        sources=CHEMBL_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
         publications=references if len(references) > 0 else None,
@@ -623,7 +624,7 @@ def get_has_part_association(koza: koza.KozaTransform, component, target, record
         predicate="biolink:has_part",
         object=component.id,
         # TODO: species_context_qualifier = species_context_qualifier,
-        sources=build_association_knowledge_sources(INFORES_CHEMBL),
+        sources=CHEMBL_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
     )

--- a/src/translator_ingest/ingests/cohd/cohd.py
+++ b/src/translator_ingest/ingests/cohd/cohd.py
@@ -10,10 +10,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     KnowledgeLevelEnum,
     AgentTypeEnum
 )
-from bmt.pydantic import (
-    entity_id,
-    get_node_class
-)
+from bmt.pydantic import get_node_class
+from translator_ingest.util.transform_utils import entity_id
 
 import koza
 from koza.model.graphs import KnowledgeGraph

--- a/src/translator_ingest/ingests/ctd/ctd.py
+++ b/src/translator_ingest/ingests/ctd/ctd.py
@@ -22,7 +22,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     KnowledgeLevelEnum,
     AgentTypeEnum,
 )
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.biolink import INFORES_CTD
 
 from koza.model.graphs import KnowledgeGraph

--- a/src/translator_ingest/ingests/ctd/ctd.py
+++ b/src/translator_ingest/ingests/ctd/ctd.py
@@ -29,13 +29,14 @@ from translator_ingest.util.biolink import INFORES_CTD
 from koza.model.graphs import KnowledgeGraph
 
 
+CTD_SOURCES = build_association_knowledge_sources(primary=INFORES_CTD)
+
 BIOLINK_AFFECTS = "biolink:affects"
 BIOLINK_CAUSES = "biolink:causes"
 BIOLINK_ASSOCIATED_WITH = "biolink:associated_with"
 BIOLINK_CORRELATED_WITH = "biolink:correlated_with"
 BIOLINK_POSITIVELY_CORRELATED = "biolink:positively_correlated_with"
 BIOLINK_NEGATIVELY_CORRELATED = "biolink:negatively_correlated_with"
-
 BIOLINK_TREATS_OR_APPLIED_OR_STUDIED_TO_TREAT = "biolink:treats_or_applied_or_studied_to_treat"
 
 CHEM_TO_DISEASE_PREDICATES = {
@@ -106,7 +107,7 @@ def transform_chemical_to_disease(koza: koza.KozaTransform, record: dict[str, An
         subject=chemical.id,
         predicate=predicate,
         object=disease.id,
-        sources=build_association_knowledge_sources(primary=INFORES_CTD),
+        sources=CTD_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent
     )
@@ -147,7 +148,7 @@ def transform_exposure_events(koza: koza.KozaTransform, record: dict[str, Any]) 
                 subject=exposure_chemical_id,
                 predicate=predicate,
                 object=disease_id,
-                sources=build_association_knowledge_sources(primary=INFORES_CTD),
+                sources=CTD_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.statistical_association,
                 agent_type=AgentTypeEnum.manual_agent
         )
@@ -164,7 +165,7 @@ def transform_exposure_events(koza: koza.KozaTransform, record: dict[str, Any]) 
                 subject=exposure_chemical_id,
                 predicate=predicate,
                 object=phenotype_id,
-                sources=build_association_knowledge_sources(primary=INFORES_CTD),
+                sources=CTD_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.statistical_association,
                 agent_type=AgentTypeEnum.manual_agent
         )
@@ -322,7 +323,7 @@ def transform_chem_gene_ixns(koza: koza.KozaTransform, record: dict[str, Any]) -
         predicate=predicate,
         object=gene_id,
         qualified_predicate=qualified_predicate,
-        sources=build_association_knowledge_sources(primary=INFORES_CTD),
+        sources=CTD_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
         publications=publications,
@@ -356,7 +357,7 @@ def transform_chem_go_enriched(koza: koza.KozaTransform, record: dict[str, Any])
         subject=chemical_id,
         predicate=BIOLINK_ASSOCIATED_WITH,
         object=go_term,
-        sources=build_association_knowledge_sources(primary=INFORES_CTD),
+        sources=CTD_SOURCES,
         knowledge_level=KnowledgeLevelEnum.statistical_association,
         agent_type=AgentTypeEnum.data_analysis_pipeline,
         p_value=p_value,
@@ -383,7 +384,7 @@ def transform_chem_pathways_enriched(koza: koza.KozaTransform, record: dict[str,
         subject=chemical_id,
         predicate=BIOLINK_ASSOCIATED_WITH,
         object=pathway_id,
-        sources=build_association_knowledge_sources(primary=INFORES_CTD),
+        sources=CTD_SOURCES,
         knowledge_level=KnowledgeLevelEnum.statistical_association,
         agent_type=AgentTypeEnum.data_analysis_pipeline,
         p_value=p_value,
@@ -439,7 +440,7 @@ def transform_pheno_term_ixns(koza: koza.KozaTransform, record: dict[str, Any]) 
         subject=chemical_id,
         predicate=BIOLINK_AFFECTS,
         object=phenotype_id,
-        sources=build_association_knowledge_sources(primary=INFORES_CTD),
+        sources=CTD_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
         publications=publications,

--- a/src/translator_ingest/ingests/ctkp/ctkp.py
+++ b/src/translator_ingest/ingests/ctkp/ctkp.py
@@ -230,7 +230,7 @@ def transform(koza: koza.KozaTransform, record: dict[str, Any]) -> KnowledgeGrap
         sources = []
         for source in record["sources"]:
             retrieval_source = RetrievalSource(
-                id=entity_id(),  # Generate unique ID
+                id=source.get("resource_id"),  # Generate unique ID
                 resource_id=source.get("resource_id"),
                 resource_role=source.get("resource_role", "primary_knowledge_source"),
                 upstream_resource_ids=source.get("upstream_resource_ids"),

--- a/src/translator_ingest/ingests/ctkp/ctkp.py
+++ b/src/translator_ingest/ingests/ctkp/ctkp.py
@@ -3,7 +3,6 @@ import gzip
 import urllib.request
 from pathlib import Path
 from typing import Any
-import uuid
 import koza
 
 from biolink_model.datamodel.pydanticmodel_v2 import (
@@ -28,7 +27,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     RetrievalSource,
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import build_association_knowledge_sources
+from bmt.pydantic import entity_id, build_association_knowledge_sources
 
 from translator_ingest.util.logging_utils import get_logger
 
@@ -183,7 +182,7 @@ def transform(koza: koza.KozaTransform, record: dict[str, Any]) -> KnowledgeGrap
     qualifiers = record.get("qualifiers", [])
 
     edge_props = {
-        "id": record.get("id", str(uuid.uuid4())),
+        "id": record.get("id", entity_id()),
         "subject": subject_id,
         "predicate": predicate,
         "object": object_id,
@@ -229,7 +228,7 @@ def transform(koza: koza.KozaTransform, record: dict[str, Any]) -> KnowledgeGrap
         sources = []
         for source in record["sources"]:
             retrieval_source = RetrievalSource(
-                id=str(uuid.uuid4()),  # Generate unique ID
+                id=entity_id(),  # Generate unique ID
                 resource_id=source.get("resource_id"),
                 resource_role=source.get("resource_role", "primary_knowledge_source"),
                 upstream_resource_ids=source.get("upstream_resource_ids"),

--- a/src/translator_ingest/ingests/ctkp/ctkp.py
+++ b/src/translator_ingest/ingests/ctkp/ctkp.py
@@ -33,6 +33,7 @@ from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.logging_utils import get_logger
 
 INFORES_CTKP = "infores:multiomics-clinicaltrials"
+CTKP_SOURCES = build_association_knowledge_sources(primary=INFORES_CTKP)
 
 logger = get_logger(__name__)
 
@@ -239,7 +240,7 @@ def transform(koza: koza.KozaTransform, record: dict[str, Any]) -> KnowledgeGrap
         edge_props["sources"] = sources
     else:
         # Default to standard source if not provided
-        edge_props["sources"] = build_association_knowledge_sources(primary=INFORES_CTKP)
+        edge_props["sources"] = CTKP_SOURCES
 
     # Determine which association class to use based on category
     categories = record.get("category", ["biolink:Association"])

--- a/src/translator_ingest/ingests/ctkp/ctkp.py
+++ b/src/translator_ingest/ingests/ctkp/ctkp.py
@@ -27,7 +27,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     RetrievalSource,
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 
 from translator_ingest.util.logging_utils import get_logger
 

--- a/src/translator_ingest/ingests/dakp/dakp.py
+++ b/src/translator_ingest/ingests/dakp/dakp.py
@@ -25,7 +25,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     ClinicalApprovalStatusEnum
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import build_association_knowledge_sources, entity_id
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 
 from translator_ingest.util.logging_utils import get_logger
 

--- a/src/translator_ingest/ingests/dakp/dakp.py
+++ b/src/translator_ingest/ingests/dakp/dakp.py
@@ -190,7 +190,7 @@ def transform(koza: koza.KozaTransform, record: dict[str, Any]) -> KnowledgeGrap
         sources = []
         for source in record["sources"]:
             retrieval_source = RetrievalSource(
-                id=entity_id(),  # Generate unique ID
+                id=source.get("resource_id"),  # Generate unique ID
                 resource_id=source.get("resource_id"),
                 resource_role=source.get("resource_role", "primary_knowledge_source"),
                 upstream_resource_ids=source.get("upstream_resource_ids"),

--- a/src/translator_ingest/ingests/dakp/dakp.py
+++ b/src/translator_ingest/ingests/dakp/dakp.py
@@ -3,7 +3,6 @@ import gzip
 import urllib.request
 from pathlib import Path
 from typing import Any
-import uuid
 import math
 import koza
 
@@ -26,7 +25,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     ClinicalApprovalStatusEnum
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources, entity_id
 
 from translator_ingest.util.logging_utils import get_logger
 
@@ -152,7 +151,7 @@ def transform(koza: koza.KozaTransform, record: dict[str, Any]) -> KnowledgeGrap
     publications = record.get("publications", [])
 
     edge_props = {
-        "id": record.get("id", str(uuid.uuid4())),
+        "id": record.get("id", entity_id()),
         "subject": subject_id,
         "predicate": predicate,
         "object": object_id,
@@ -189,7 +188,7 @@ def transform(koza: koza.KozaTransform, record: dict[str, Any]) -> KnowledgeGrap
         sources = []
         for source in record["sources"]:
             retrieval_source = RetrievalSource(
-                id=str(uuid.uuid4()),  # Generate unique ID
+                id=entity_id(),  # Generate unique ID
                 resource_id=source.get("resource_id"),
                 resource_role=source.get("resource_role", "primary_knowledge_source"),
                 upstream_resource_ids=source.get("upstream_resource_ids"),

--- a/src/translator_ingest/ingests/dakp/dakp.py
+++ b/src/translator_ingest/ingests/dakp/dakp.py
@@ -31,6 +31,7 @@ from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.logging_utils import get_logger
 
 INFORES_DAKP = "infores:multiomics-drugapprovals"
+DAKP_SOURCES = build_association_knowledge_sources(primary=INFORES_DAKP)
 
 logger = get_logger(__name__)
 
@@ -199,7 +200,7 @@ def transform(koza: koza.KozaTransform, record: dict[str, Any]) -> KnowledgeGrap
         edge_props["sources"] = sources
     else:
         # Default to standard source if not provided
-        edge_props["sources"] = build_association_knowledge_sources(primary=INFORES_DAKP)
+        edge_props["sources"] = DAKP_SOURCES
 
     # Determine which association class to use based on category
     categories = record.get("category", ["biolink:Association"])

--- a/src/translator_ingest/ingests/dgidb/dgidb.py
+++ b/src/translator_ingest/ingests/dgidb/dgidb.py
@@ -3,7 +3,8 @@ import koza
 import pandas as pd
 from typing import Any, Iterable
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from biolink_model.datamodel.pydanticmodel_v2 import (
     ChemicalEntity,
     Gene,    ## because terms/IDs dgidb gives are for genes

--- a/src/translator_ingest/ingests/diseases/diseases.py
+++ b/src/translator_ingest/ingests/diseases/diseases.py
@@ -1,4 +1,4 @@
-from bmt.pydantic import entity_id
+from translator_ingest.util.transform_utils import entity_id
 import koza
 from typing import Any, Iterable
 from koza.model.graphs import KnowledgeGraph

--- a/src/translator_ingest/ingests/drug_rep_hub/drug_rep_hub.py
+++ b/src/translator_ingest/ingests/drug_rep_hub/drug_rep_hub.py
@@ -17,7 +17,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     AgentTypeEnum,
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 
 
 inchikey_regex = re.compile('^[A-Z]{14}-[A-Z]{10}-[A-Z]$')

--- a/src/translator_ingest/ingests/drug_rep_hub/drug_rep_hub.py
+++ b/src/translator_ingest/ingests/drug_rep_hub/drug_rep_hub.py
@@ -24,6 +24,7 @@ from translator_ingest.util.transform_utils import entity_id
 inchikey_regex = re.compile('^[A-Z]{14}-[A-Z]{10}-[A-Z]$')
 
 INFORES_DRUG_REP_HUB = "infores:drug-repurposing-hub"
+DRUG_REP_HUB_SOURCES = build_association_knowledge_sources(primary=INFORES_DRUG_REP_HUB)
 PUBCHEM_PREFIX = "PUBCHEM.COMPOUND:"
 INCHIKEY_PREFIX = "INCHIKEY:"
 SMILES_PREFIX = "SMILES:"
@@ -132,7 +133,7 @@ def create_disease_association(chemical, indication, indication_info, predicate,
         predicate=predicate,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
-        sources=build_association_knowledge_sources(INFORES_DRUG_REP_HUB),
+        sources=DRUG_REP_HUB_SOURCES,
         original_object = indication,
         #TODO: clinical_approval_status=clinical_approval_status,
         #TODO: max_research_phase=max_research_phase,
@@ -153,7 +154,7 @@ def create_chemical_role_association(chemical, indication, indication_info, pred
         object=chemical_role.id,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
-        sources=build_association_knowledge_sources(INFORES_DRUG_REP_HUB),
+        sources=DRUG_REP_HUB_SOURCES,
         original_object = indication
     )
     return chemical_role, association
@@ -175,7 +176,7 @@ def create_target_association(chemical, target_gene_symbol, moa):
         object=target.id,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
-        sources=build_association_knowledge_sources(INFORES_DRUG_REP_HUB),
+        sources=DRUG_REP_HUB_SOURCES,
         description = moa
     )
     return target, association

--- a/src/translator_ingest/ingests/drugcentral/drugcentral.py
+++ b/src/translator_ingest/ingests/drugcentral/drugcentral.py
@@ -3,7 +3,8 @@ import koza
 from koza.model.graphs import KnowledgeGraph
 from typing import Any, Iterable
 ## build_association_knowledge_sources should be able to handle source_record_urls
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 ## using bmt to get UMLS semantic types for DiseaseOrPheno
 from translator_ingest.util.biolink import (
     INFORES_DRUGCENTRAL,

--- a/src/translator_ingest/ingests/gene2phenotype/gene2phenotype.py
+++ b/src/translator_ingest/ingests/gene2phenotype/gene2phenotype.py
@@ -2,7 +2,7 @@
 import koza
 from typing import Any, Iterable
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id
+from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.biolink import INFORES_EBI_G2P
 from biolink_model.datamodel.pydanticmodel_v2 import (
     Gene,

--- a/src/translator_ingest/ingests/geneticskp/geneticskp.py
+++ b/src/translator_ingest/ingests/geneticskp/geneticskp.py
@@ -38,6 +38,7 @@ from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.logging_utils import get_logger
 
 INFORES_GENETICSKP = "infores:geneticskp"
+GENETICSKP_SOURCES = build_association_knowledge_sources(primary=INFORES_GENETICSKP)
 
 logger = get_logger(__name__)
 
@@ -225,7 +226,7 @@ def transform(koza: koza.KozaTransform, record: Dict[str, Any]) -> Optional[Know
     if "sources" in record:
         edge_props["sources"] = record["sources"]
     else:
-        edge_props["sources"] = build_association_knowledge_sources(primary=INFORES_GENETICSKP)
+        edge_props["sources"] = GENETICSKP_SOURCES
 
     # Determine association type based on predicate and node types
     categories = record.get("category", ["biolink:Association"])

--- a/src/translator_ingest/ingests/geneticskp/geneticskp.py
+++ b/src/translator_ingest/ingests/geneticskp/geneticskp.py
@@ -3,7 +3,7 @@ GeneticsKP ingest.
 
 This ingest processes KGX data from GeneticsKP MAGMA analysis.
 The data comes as a tar.gz file containing:
-- edges_geneticsKP_magma.jsonl: Edge information 
+- edges_geneticsKP_magma.jsonl: Edge information
 - nodes_geneticsKP_magma.jsonl: Node information
 
 This ingest validates and transforms the KGX data through Pydantic classes.
@@ -14,7 +14,6 @@ import gzip
 import tarfile
 from pathlib import Path
 from typing import Any, Dict, Optional
-import uuid
 from datetime import datetime
 import koza
 
@@ -33,7 +32,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     AgentTypeEnum,
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import build_association_knowledge_sources
+from bmt.pydantic import build_association_knowledge_sources, entity_id
 
 from translator_ingest.util.logging_utils import get_logger
 
@@ -44,7 +43,7 @@ logger = get_logger(__name__)
 
 def get_latest_version() -> str:
     """Return the latest version of GeneticsKP data.
-    
+
     Uses the current date as the version since we're using a static file.
     """
     return datetime.now().strftime("%Y-%m-%d")
@@ -55,7 +54,7 @@ def create_node(node_data: dict) -> Any:
     node_id = node_data.get("id")
     name = node_data.get("name")
     categories = node_data.get("category", [])
-    
+
     if not categories:
         logger.warning(f"No category found for node {node_id}, using NamedThing")
         return NamedThing(
@@ -63,10 +62,10 @@ def create_node(node_data: dict) -> Any:
             name=name,
             category=["biolink:NamedThing"]
         )
-    
+
     # Get the primary category
     category = categories[0] if isinstance(categories, list) else categories
-    
+
     # Map category to appropriate Pydantic class
     if "Gene" in category:
         return Gene(
@@ -117,7 +116,7 @@ def create_node(node_data: dict) -> Any:
 @koza.on_data_begin(tag="edges")
 def on_data_begin_edges(koza: koza.KozaTransform) -> None:
     """Extract tar.gz and load all nodes into memory before processing edges."""
-    
+
     # First extract the tar.gz if it exists
     tar_path = Path(koza.input_files_dir) / "genetics_magma.tar.gz"
     if tar_path.exists():
@@ -125,25 +124,25 @@ def on_data_begin_edges(koza: koza.KozaTransform) -> None:
         with tarfile.open(tar_path, "r:gz") as tar:
             tar.extractall(koza.input_files_dir)
         logger.info("Extraction complete")
-    
+
     nodes_file_path = Path(koza.input_files_dir) / "nodes_geneticsKP_magma.jsonl"
-    
+
     # Check if file exists - if not, it might be gzipped
     if not nodes_file_path.exists():
         nodes_file_path = Path(koza.input_files_dir) / "nodes_geneticsKP_magma.jsonl.gz"
-    
+
     logger.info("Loading all nodes into memory...")
     nodes_lookup = {}
     nodes_written = set()  # Track which nodes have been written
     node_count = 0
-    
+
     if nodes_file_path.suffix == '.gz':
         opener = gzip.open
         mode = 'rt'
     else:
         opener = open
         mode = 'r'
-    
+
     with opener(nodes_file_path, mode) as f:
         for line in f:
             if line.strip():
@@ -152,7 +151,7 @@ def on_data_begin_edges(koza: koza.KozaTransform) -> None:
                 if node_id:
                     nodes_lookup[node_id] = node
                     node_count += 1
-    
+
     logger.info(f"Loaded {node_count} nodes into memory")
     koza.state["nodes_lookup"] = nodes_lookup
     koza.state["nodes_written"] = nodes_written
@@ -161,81 +160,81 @@ def on_data_begin_edges(koza: koza.KozaTransform) -> None:
 @koza.transform_record(tag="edges")
 def transform(koza: koza.KozaTransform, record: Dict[str, Any]) -> Optional[KnowledgeGraph]:
     """Transform edge records into KnowledgeGraph objects with validated nodes and edges."""
-    
+
     # Get edge properties
     subject_id = record.get("subject")
     object_id = record.get("object")
     predicate = record.get("predicate")
-    
+
     if not all([subject_id, object_id, predicate]):
         logger.warning(f"Skipping edge missing required fields: {record}")
         return None
-    
+
     # Get nodes lookup and written tracker from state
     nodes_lookup = koza.state.get("nodes_lookup", {})
     nodes_written = koza.state.get("nodes_written", set())
-    
+
     # Look up subject and object nodes
     subject_node_data = nodes_lookup.get(subject_id)
     object_node_data = nodes_lookup.get(object_id)
-    
+
     if not subject_node_data or not object_node_data:
         logger.warning(f"Skipping edge - missing node data for {subject_id} or {object_id}")
         return None
-    
+
     # Only create nodes that haven't been written yet
     nodes_to_write = []
-    
+
     if subject_id not in nodes_written:
         subject_node = create_node(subject_node_data)
         nodes_to_write.append(subject_node)
         nodes_written.add(subject_id)
-    
+
     if object_id not in nodes_written:
         object_node = create_node(object_node_data)
         nodes_to_write.append(object_node)
         nodes_written.add(object_id)
-    
+
     # Build edge properties
     edge_props = {
-        "id": record.get("id", str(uuid.uuid4())),
+        "id": record.get("id", entity_id()),
         "subject": subject_id,
         "predicate": predicate,
         "object": object_id,
         "knowledge_level": record.get("knowledge_level", KnowledgeLevelEnum.statistical_association),
         "agent_type": record.get("agent_type", AgentTypeEnum.computational_model),
     }
-    
+
     # Add optional properties if present
     if "publications" in record:
         edge_props["publications"] = record["publications"]
-    
+
     # Add attributes like p-value, z-score, etc if present
     if "has_attribute" in record:
         edge_props["has_attribute"] = record["has_attribute"]
-    
+
     # Handle qualifiers if present
-    for qualifier_key in ["subject_aspect_qualifier", "subject_direction_qualifier", 
+    for qualifier_key in ["subject_aspect_qualifier", "subject_direction_qualifier",
                           "object_aspect_qualifier", "object_direction_qualifier",
                           "qualified_predicate"]:
         if qualifier_key in record:
             edge_props[qualifier_key] = record[qualifier_key]
-    
+
     # Handle sources - if not provided, use default
     if "sources" in record:
         edge_props["sources"] = record["sources"]
     else:
         edge_props["sources"] = build_association_knowledge_sources(primary=INFORES_GENETICSKP)
-    
+
     # Determine association type based on predicate and node types
     categories = record.get("category", ["biolink:Association"])
     category = categories[0] if isinstance(categories, list) else categories
-    
+
     # Create appropriate association based on category or predicate
     # We need to check object node type from the data, not the Pydantic object
     object_categories = object_node_data.get("category", [])
     object_category = object_categories[0] if isinstance(object_categories, list) else object_categories
-    
+
     if "genetically_associated_with" in predicate:
         if "Disease" in str(object_category):
             association = GeneToDiseaseAssociation(**edge_props)
@@ -250,6 +249,6 @@ def transform(koza: koza.KozaTransform, record: Dict[str, Any]) -> Optional[Know
     else:
         # Default to generic Association
         association = Association(**edge_props)
-    
+
     # Return KnowledgeGraph with only the edge and new nodes
     return KnowledgeGraph(nodes=nodes_to_write, edges=[association])

--- a/src/translator_ingest/ingests/geneticskp/geneticskp.py
+++ b/src/translator_ingest/ingests/geneticskp/geneticskp.py
@@ -32,7 +32,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     AgentTypeEnum,
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import build_association_knowledge_sources, entity_id
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 
 from translator_ingest.util.logging_utils import get_logger
 

--- a/src/translator_ingest/ingests/go_cam/go_cam.py
+++ b/src/translator_ingest/ingests/go_cam/go_cam.py
@@ -1,13 +1,13 @@
 import json
 import tarfile
 import tempfile
-import uuid
 from pathlib import Path
 from typing import Any, Iterable
 
 import koza
 import requests
 
+from bmt.pydantic import entity_id
 from biolink_model.datamodel.pydanticmodel_v2 import (
     Gene,
     KnowledgeLevelEnum,
@@ -340,7 +340,7 @@ def transform_go_cam_models(koza: koza.KozaTransform, data: Iterable[dict[str, A
 
             # Create the gene-to-gene association
             association = GeneToGeneAssociation(
-                id=str(uuid.uuid4()),
+                id=entity_id(),
                 subject=normalized_source_id,
                 predicate=biolink_predicate,
                 object=normalized_target_id,

--- a/src/translator_ingest/ingests/go_cam/go_cam.py
+++ b/src/translator_ingest/ingests/go_cam/go_cam.py
@@ -7,7 +7,7 @@ from typing import Any, Iterable
 import koza
 import requests
 
-from bmt.pydantic import entity_id
+from translator_ingest.util.transform_utils import entity_id
 from biolink_model.datamodel.pydanticmodel_v2 import (
     Gene,
     KnowledgeLevelEnum,

--- a/src/translator_ingest/ingests/goa/goa.py
+++ b/src/translator_ingest/ingests/goa/goa.py
@@ -20,7 +20,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     RNAProduct,
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.biolink import INFORES_GOA, INFORES_INTACT
 
 # Constants

--- a/src/translator_ingest/ingests/gtopdb/gtopdb.py
+++ b/src/translator_ingest/ingests/gtopdb/gtopdb.py
@@ -1,4 +1,3 @@
-import uuid
 import koza
 import pandas as pd
 import requests
@@ -254,7 +253,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 causal_mechanism_qualifier = CausalMechanismQualifierEnum.potentiation
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
+                id=entity_id(),
                 subject=subject.id,
                 object=object.id,
                 ## Five edge attributes in order
@@ -899,7 +898,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 causal_mechanism_qualifier = CausalMechanismQualifierEnum.feedback_inhibition
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
+                id=entity_id(),
                 subject=subject.id,
                 object=object.id,
                 ## Five edge attributes in order
@@ -989,7 +988,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 object_direction_qualifier = current_direction_mapping[0]
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
+                id=entity_id(),
                 subject=subject.id,
                 object=object.id,
                 ## Five edge attributes in order
@@ -1073,7 +1072,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 object_direction_qualifier = current_direction_mapping[0]
 
             association = ChemicalAffectsGeneAssociation(
-                id=str(uuid.uuid4()),
+                id=entity_id(),
                 subject=subject.id,
                 object=object.id,
                 ## Five edge attributes in order

--- a/src/translator_ingest/ingests/gtopdb/gtopdb.py
+++ b/src/translator_ingest/ingests/gtopdb/gtopdb.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 
 from biolink_model.datamodel.pydanticmodel_v2 import (
     # Gene,

--- a/src/translator_ingest/ingests/gtopdb/gtopdb.py
+++ b/src/translator_ingest/ingests/gtopdb/gtopdb.py
@@ -29,6 +29,8 @@ from translator_ingest.util.biolink import (
     INFORES_GTOPDB
 )
 
+GTOPDB_SOURCES = build_association_knowledge_sources(primary=INFORES_GTOPDB)
+
 # adding additional needed resources
 BIOLINK_CAUSES = "biolink:causes"
 BIOLINK_AFFECTS = "biolink:affects"
@@ -211,7 +213,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     object_direction_qualifier = current_direction_mapping[0],
                     causal_mechanism_qualifier = causal_mechanism_qualifier,
                     ## other attributes
-                    sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                    sources=GTOPDB_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                 )
@@ -221,7 +223,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:directly_physically_interacts_with",
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
                 ## Qi review comment, seems that PairwiseMolecularInteraction don't accept causal_mechanism_qualifier
@@ -264,7 +266,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 object_direction_qualifier = object_direction_qualifier,
                 causal_mechanism_qualifier = causal_mechanism_qualifier,
                 ## other edge attributes
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
             )
@@ -322,7 +324,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     object_direction_qualifier = object_direction_qualifier,
                     causal_mechanism_qualifier = causal_mechanism_qualifier,
                     ## other edge attributes
-                    sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                    sources=GTOPDB_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                 )
@@ -332,7 +334,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:directly_physically_interacts_with",
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
                 ## Qi review comment, seems that PairwiseMolecularInteraction don't accept causal_mechanism_qualifier
@@ -466,7 +468,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     object_direction_qualifier = object_direction_qualifier,
                     causal_mechanism_qualifier = causal_mechanism_qualifier,
                     ## other edge attributes
-                    sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                    sources=GTOPDB_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                 )
@@ -476,7 +478,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:directly_physically_interacts_with",
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
                 ## Qi review comment, seems that PairwiseMolecularInteraction don't accept causal_mechanism_qualifier
@@ -561,7 +563,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     object_direction_qualifier = object_direction_qualifier,
                     causal_mechanism_qualifier = causal_mechanism_qualifier,
                     ## other edge attributes
-                    sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                    sources=GTOPDB_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                 )
@@ -571,7 +573,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:directly_physically_interacts_with",
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
                 ## Qi review comment, seems that PairwiseMolecularInteraction don't accept causal_mechanism_qualifier
@@ -626,7 +628,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     object_direction_qualifier = object_direction_qualifier,
                     causal_mechanism_qualifier= causal_mechanism_qualifier,
                     ## other edge attributes
-                    sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                    sources=GTOPDB_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                 )
@@ -636,7 +638,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:directly_physically_interacts_with",
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
                 ## Qi review comment, seems that PairwiseMolecularInteraction don't accept causal_mechanism_qualifier
@@ -683,7 +685,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     object_direction_qualifier = object_direction_qualifier,
                     causal_mechanism_qualifier = causal_mechanism_qualifier,
                     ## other edge attributes
-                    sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                    sources=GTOPDB_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                 )
@@ -693,7 +695,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:directly_physically_interacts_with",
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
                 ## Qi review comment, seems that PairwiseMolecularInteraction don't accept causal_mechanism_qualifier
@@ -739,7 +741,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     object_direction_qualifier= object_direction_qualifier,
                     causal_mechanism_qualifier = causal_mechanism_qualifier,
                     ## other edge attributes
-                    sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                    sources=GTOPDB_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                 )
@@ -749,7 +751,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:directly_physically_interacts_with",
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
                 ## Qi review comment, seems that PairwiseMolecularInteraction don't accept causal_mechanism_qualifier
@@ -804,7 +806,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     object_direction_qualifier = object_direction_qualifier,
                     causal_mechanism_qualifier = causal_mechanism_qualifier,
                     ## other edge attributes
-                    sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                    sources=GTOPDB_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                 )
@@ -814,7 +816,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:directly_physically_interacts_with",
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
                 ## Qi review comment, seems that PairwiseMolecularInteraction don't accept causal_mechanism_qualifier
@@ -863,7 +865,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     object_direction_qualifier = object_direction_qualifier,
                     causal_mechanism_qualifier = causal_mechanism_qualifier,
                     ## other edge attributes
-                    sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                    sources=GTOPDB_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                 )
@@ -873,7 +875,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:directly_physically_interacts_with",
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
                 ## Qi review comment, seems that PairwiseMolecularInteraction don't accept causal_mechanism_qualifier
@@ -909,7 +911,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 object_direction_qualifier = object_direction_qualifier,
                 causal_mechanism_qualifier = causal_mechanism_qualifier,
                 ## other edge attributes
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
             )
@@ -947,7 +949,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     object_direction_qualifier = object_direction_qualifier,
                     causal_mechanism_qualifier = causal_mechanism_qualifier,
                     ## other edge attributes
-                    sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                    sources=GTOPDB_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                 )
@@ -957,7 +959,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:directly_physically_interacts_with",
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
                 ## Qi review comment, seems that PairwiseMolecularInteraction don't accept causal_mechanism_qualifier
@@ -999,7 +1001,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 object_direction_qualifier = object_direction_qualifier,
                 causal_mechanism_qualifier = causal_mechanism_qualifier,
                 ## other edge attributes
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
 
@@ -1033,7 +1035,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     object_direction_qualifier = object_direction_qualifier,
                     causal_mechanism_qualifier = causal_mechanism_qualifier,
                     ## other edge attributes
-                    sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                    sources=GTOPDB_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                 )
@@ -1043,7 +1045,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 subject=subject.id,
                 object=object.id,
                 predicate = "biolink:directly_physically_interacts_with",
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
                 ## Qi review comment, seems that PairwiseMolecularInteraction don't accept causal_mechanism_qualifier
@@ -1083,7 +1085,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                 object_direction_qualifier = object_direction_qualifier,
                 causal_mechanism_qualifier = causal_mechanism_qualifier,
                 ## other edge attributes
-                sources=build_association_knowledge_sources(primary=INFORES_GTOPDB),
+                sources=GTOPDB_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
             )

--- a/src/translator_ingest/ingests/hpoa/hpoa.py
+++ b/src/translator_ingest/ingests/hpoa/hpoa.py
@@ -33,7 +33,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
 )
 
 from translator_ingest.util.github import GitHubReleases
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.biolink import INFORES_HPOA
 
 from translator_ingest.ingests.hpoa.phenotype_ingest_utils import (

--- a/src/translator_ingest/ingests/hpoa/hpoa.py
+++ b/src/translator_ingest/ingests/hpoa/hpoa.py
@@ -48,6 +48,8 @@ from translator_ingest.ingests.hpoa.phenotype_ingest_utils import (
     hpo_to_mode_of_inheritance,
 )
 
+HPOA_SOURCES = build_association_knowledge_sources(primary=INFORES_HPOA)
+
 
 def get_latest_version() -> str:
     ghr = GitHubReleases(git_org="obophenotype", git_repo="human-phenotype-ontology")
@@ -408,7 +410,7 @@ def transform_gene_to_phenotype_record(
         has_total=frequency.has_total,
         disease_context_qualifier=dis_id,
         publications=publications,
-        sources=build_association_knowledge_sources(primary=INFORES_HPOA),
+        sources=HPOA_SOURCES,
         knowledge_level=KnowledgeLevelEnum.logical_entailment,
         agent_type=AgentTypeEnum.automated_agent,
         **{},

--- a/src/translator_ingest/ingests/hpoa/phenotype_ingest_utils.py
+++ b/src/translator_ingest/ingests/hpoa/phenotype_ingest_utils.py
@@ -14,6 +14,11 @@ from translator_ingest.util.biolink import  (
     INFORES_HPOA
 )
 
+HPOA_MEDGEN_OMIM_SOURCES = build_association_knowledge_sources(primary=INFORES_HPOA, supporting=[INFORES_MEDGEN, INFORES_OMIM])
+HPOA_OMIM_SOURCES = build_association_knowledge_sources(primary=INFORES_HPOA, supporting=[INFORES_OMIM])
+HPOA_ORPHANET_SOURCES = build_association_knowledge_sources(primary=INFORES_HPOA, supporting=[INFORES_ORPHANET])
+HPOA_DECIPHER_SOURCES = build_association_knowledge_sources(primary=INFORES_HPOA, supporting=[INFORES_DECIFER])
+
 
 def get_hpoa_association_sources(source_id: str) -> list[RetrievalSource]:
     """
@@ -25,16 +30,16 @@ def get_hpoa_association_sources(source_id: str) -> list[RetrievalSource]:
     :return: Union[list[RetrievalSource], list[str]] of source infores identifiers
     """
     if "medgen" in source_id:
-        return build_association_knowledge_sources(primary=INFORES_HPOA, supporting=[INFORES_MEDGEN, INFORES_OMIM])
+        return HPOA_MEDGEN_OMIM_SOURCES
 
     elif source_id.startswith("OMIM"):
-        return build_association_knowledge_sources(primary=INFORES_HPOA, supporting=[INFORES_OMIM])
+        return HPOA_OMIM_SOURCES
 
     elif "orphadata" in source_id or source_id.startswith("ORPHA") or "orpha" in source_id.lower():
-        return build_association_knowledge_sources(primary=INFORES_HPOA, supporting=[INFORES_ORPHANET])
+        return HPOA_ORPHANET_SOURCES
 
     elif source_id.startswith("DECIPHER"):
-        return build_association_knowledge_sources(primary=INFORES_HPOA, supporting=[INFORES_DECIFER])
+        return HPOA_DECIPHER_SOURCES
 
     else:
         raise ValueError(f"Unknown source '{source_id}' value, can't set the primary knowledge source")

--- a/src/translator_ingest/ingests/hpoa/phenotype_ingest_utils.py
+++ b/src/translator_ingest/ingests/hpoa/phenotype_ingest_utils.py
@@ -5,7 +5,7 @@ from typing import Optional
 from loguru import logger
 from pydantic import BaseModel
 from biolink_model.datamodel.pydanticmodel_v2 import RetrievalSource
-from bmt.pydantic import build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
 from translator_ingest.util.biolink import  (
     INFORES_MEDGEN,
     INFORES_OMIM,

--- a/src/translator_ingest/ingests/icees/icees.py
+++ b/src/translator_ingest/ingests/icees/icees.py
@@ -13,11 +13,9 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     AgentTypeEnum
 )
 
-from bmt.pydantic import (
-    entity_id,
-    get_node_class,
-    build_association_knowledge_sources
-)
+from bmt.pydantic import get_node_class
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from koza.model.graphs import KnowledgeGraph
 
 from translator_ingest.util.biolink import get_biolink_model_toolkit

--- a/src/translator_ingest/ingests/intact/intact.py
+++ b/src/translator_ingest/ingests/intact/intact.py
@@ -12,7 +12,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
 )
 from translator_ingest.util.biolink import INFORES_INTACT
 from translator_ingest.util.http_utils import get_ftp_modify_date
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from koza.model.graphs import KnowledgeGraph
 
 # Allowed interaction types as per RIG documentation

--- a/src/translator_ingest/ingests/intact/intact.py
+++ b/src/translator_ingest/ingests/intact/intact.py
@@ -16,6 +16,8 @@ from translator_ingest.util.biolink import build_association_knowledge_sources
 from translator_ingest.util.transform_utils import entity_id
 from koza.model.graphs import KnowledgeGraph
 
+INTACT_SOURCES = build_association_knowledge_sources(primary=INFORES_INTACT)
+
 # Allowed interaction types as per RIG documentation
 ALLOWED_INTERACTION_TYPES = {
     "association",
@@ -409,7 +411,7 @@ def transform_record(koza: koza.KozaTransform, record: dict[str, Any]) -> Knowle
         predicate=predicate,
         object=entity_b.id,
         publications=publications,
-        sources=build_association_knowledge_sources(primary=INFORES_INTACT),
+        sources=INTACT_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
     )

--- a/src/translator_ingest/ingests/panther/panther.py
+++ b/src/translator_ingest/ingests/panther/panther.py
@@ -13,7 +13,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     KnowledgeLevelEnum,
     AgentTypeEnum, GeneFamily
 )
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 
 import koza
 from koza.model.graphs import KnowledgeGraph

--- a/src/translator_ingest/ingests/panther/panther.py
+++ b/src/translator_ingest/ingests/panther/panther.py
@@ -28,6 +28,8 @@ from translator_ingest.ingests.panther.panther_orthologs_utils import (
     GENE_FAMILY_ID_COL,
 )
 
+PANTHER_SOURCES = build_association_knowledge_sources(primary="infores:panther")
+
 
 def get_latest_version() -> str:
     try:
@@ -106,7 +108,7 @@ def transform_gene_to_gene_orthology(
         object=gene_b.id,
         predicate="biolink:orthologous_to",
         has_evidence=orthology_evidence,
-        sources=build_association_knowledge_sources(primary="infores:panther"),
+        sources=PANTHER_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_validation_of_automated_agent
     )
@@ -115,7 +117,7 @@ def transform_gene_to_gene_orthology(
         subject=gene_a.id,
         object=gene_family.id,
         predicate="biolink:member_of",
-        sources=build_association_knowledge_sources(primary="infores:panther"),
+        sources=PANTHER_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.automated_agent
     )
@@ -124,7 +126,7 @@ def transform_gene_to_gene_orthology(
         subject=gene_b.id,
         object=gene_family.id,
         predicate="biolink:member_of",
-        sources=build_association_knowledge_sources(primary="infores:panther"),
+        sources=PANTHER_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.automated_agent
     )

--- a/src/translator_ingest/ingests/pathbank/pathbank.py
+++ b/src/translator_ingest/ingests/pathbank/pathbank.py
@@ -26,7 +26,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     AgentTypeEnum,
 )
 
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.ingests.pathbank.interaction_mapping import map_interaction_edge
 from translator_ingest.util.biolink import INFORES_PATHBANK
 from translator_ingest.util.http_utils import get_modify_date

--- a/src/translator_ingest/ingests/pathbank/pathbank.py
+++ b/src/translator_ingest/ingests/pathbank/pathbank.py
@@ -32,6 +32,8 @@ from translator_ingest.ingests.pathbank.interaction_mapping import map_interacti
 from translator_ingest.util.biolink import INFORES_PATHBANK
 from translator_ingest.util.http_utils import get_modify_date
 
+PATHBANK_SOURCES = build_association_knowledge_sources(primary=INFORES_PATHBANK)
+
 EXCLUDED_OCCURS_IN_GO_TERMS = {
     # This GO ID currently normalizes to BiologicalProcess, which violates the expected
     # Pathway occurs_in object categories for this ingest.
@@ -250,9 +252,7 @@ def _create_compound_node_and_edges(
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=primary_curie,
-        sources=build_association_knowledge_sources(
-            primary=INFORES_PATHBANK,
-        ),
+        sources=PATHBANK_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
     )
@@ -343,9 +343,7 @@ def _create_protein_node_and_edges(
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=primary_curie,
-        sources=build_association_knowledge_sources(
-            primary=INFORES_PATHBANK,
-        ),
+        sources=PATHBANK_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
     )
@@ -424,9 +422,7 @@ def _create_protein_complex_node_and_edges(
             subject=pwp_curie,
             predicate="biolink:has_part",
             object=protein_id,
-            sources=build_association_knowledge_sources(
-                primary=INFORES_PATHBANK,
-            ),
+            sources=PATHBANK_SOURCES,
             knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
             agent_type=AgentTypeEnum.manual_agent,
         )
@@ -439,9 +435,7 @@ def _create_protein_complex_node_and_edges(
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=pwp_curie,
-        sources=build_association_knowledge_sources(
-            primary=INFORES_PATHBANK,
-        ),
+        sources=PATHBANK_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
     )
@@ -518,9 +512,7 @@ def _create_nucleic_acid_node_and_edges(
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=primary_curie,
-        sources=build_association_knowledge_sources(
-            primary=INFORES_PATHBANK,
-        ),
+        sources=PATHBANK_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
     )
@@ -624,9 +616,7 @@ def _create_reaction_node_and_edges(
                 subject=primary_curie,
                 predicate="biolink:has_input",
                 object=object_curie,
-                sources=build_association_knowledge_sources(
-                    primary=INFORES_PATHBANK,
-                ),
+                sources=PATHBANK_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
             )
@@ -658,9 +648,7 @@ def _create_reaction_node_and_edges(
                 subject=primary_curie,
                 predicate="biolink:has_output",
                 object=object_curie,
-                sources=build_association_knowledge_sources(
-                    primary=INFORES_PATHBANK,
-                ),
+                sources=PATHBANK_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
             )
@@ -690,9 +678,7 @@ def _create_reaction_node_and_edges(
                 subject=subject_curie,
                 predicate="biolink:catalyzes",
                 object=primary_curie,
-                sources=build_association_knowledge_sources(
-                    primary=INFORES_PATHBANK,
-                ),
+                sources=PATHBANK_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
             )
@@ -705,9 +691,7 @@ def _create_reaction_node_and_edges(
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=primary_curie,
-        sources=build_association_knowledge_sources(
-            primary=INFORES_PATHBANK,
-        ),
+        sources=PATHBANK_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
     )
@@ -777,9 +761,7 @@ def _create_bound_node_and_edges(
                 subject=pwb_curie,
                 predicate="biolink:has_part",
                 object=object_curie,
-                sources=build_association_knowledge_sources(
-                    primary=INFORES_PATHBANK,
-                ),
+                sources=PATHBANK_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
             )
@@ -792,9 +774,7 @@ def _create_bound_node_and_edges(
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=pwb_curie,
-        sources=build_association_knowledge_sources(
-            primary=INFORES_PATHBANK,
-        ),
+        sources=PATHBANK_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
     )
@@ -883,9 +863,7 @@ def _create_element_collection_node_and_edges(
         subject=pathway_curie,
         predicate="biolink:has_participant",
         object=primary_curie,
-        sources=build_association_knowledge_sources(
-            primary=INFORES_PATHBANK,
-        ),
+        sources=PATHBANK_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
     )
@@ -1000,9 +978,7 @@ def _create_interaction_edges(
                 "subject": left_curie,
                 "predicate": predicate,
                 "object": right_curie,
-                "sources": build_association_knowledge_sources(
-                    primary=INFORES_PATHBANK,
-                ),
+                "sources": PATHBANK_SOURCES,
                 "knowledge_level": KnowledgeLevelEnum.knowledge_assertion,
                 "agent_type": AgentTypeEnum.manual_agent,
             }
@@ -1063,9 +1039,7 @@ def _create_subcellular_location_nodes_and_edges(
         subject=pathway_curie,
         predicate="biolink:occurs_in",
         object=location_curie,
-        sources=build_association_knowledge_sources(
-            primary=INFORES_PATHBANK,
-        ),
+        sources=PATHBANK_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
     )
@@ -1116,9 +1090,7 @@ def _create_tissue_nodes_and_edges(
         subject=pathway_curie,
         predicate="biolink:occurs_in",
         object=tissue_curie,
-        sources=build_association_knowledge_sources(
-            primary=INFORES_PATHBANK,
-        ),
+        sources=PATHBANK_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
     )

--- a/src/translator_ingest/ingests/semmeddb/semmeddb.py
+++ b/src/translator_ingest/ingests/semmeddb/semmeddb.py
@@ -31,6 +31,8 @@ from translator_ingest.util.biolink import build_association_knowledge_sources
 from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.biolink import INFORES_SEMMEDDB
 
+SEMMEDDB_SOURCES = build_association_knowledge_sources(primary=INFORES_SEMMEDDB)
+
 PREFIX_TO_CLASS: dict[str, type[NamedThing]] = {
     "NCBIGene": Gene,
     "HGNC": Gene,
@@ -438,9 +440,7 @@ def transform_semmeddb_edge(
         "predicate": predicate,
         "object": object_id,
         "publications": publications,
-        "sources": build_association_knowledge_sources(
-            primary=INFORES_SEMMEDDB,
-        ),
+        "sources": SEMMEDDB_SOURCES,
         "knowledge_level": KnowledgeLevelEnum.not_provided,
         "agent_type": AgentTypeEnum.text_mining_agent,
     }

--- a/src/translator_ingest/ingests/semmeddb/semmeddb.py
+++ b/src/translator_ingest/ingests/semmeddb/semmeddb.py
@@ -27,7 +27,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     Study,
     TextMiningStudyResult,
 )
-from bmt.pydantic import build_association_knowledge_sources, entity_id
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.biolink import INFORES_SEMMEDDB
 
 PREFIX_TO_CLASS: dict[str, type[NamedThing]] = {

--- a/src/translator_ingest/ingests/sider/sider.py
+++ b/src/translator_ingest/ingests/sider/sider.py
@@ -13,7 +13,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     KnowledgeLevelEnum,
     AgentTypeEnum,
 )
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from translator_ingest import INGESTS_PARSER_PATH
 
 SIDER_INGEST_PATH = INGESTS_PARSER_PATH / "sider"

--- a/src/translator_ingest/ingests/signor/signor.py
+++ b/src/translator_ingest/ingests/signor/signor.py
@@ -30,6 +30,8 @@ from translator_ingest.util.biolink import (
     INFORES_SIGNOR
 )
 
+SIGNOR_SOURCES = build_association_knowledge_sources(primary=INFORES_SIGNOR)
+
 # adding additional needed resources
 BIOLINK_CAUSES = "biolink:causes"
 BIOLINK_AFFECTS = "biolink:affects"
@@ -321,7 +323,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     id=entity_id(),
                     subject=subject.id,
                     object=object.id,
-                    sources=build_association_knowledge_sources(primary=INFORES_SIGNOR),
+                    sources=SIGNOR_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                     ## five edge attributes in order
@@ -340,7 +342,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     subject=subject.id,
                     object=object.id,
                     predicate = "biolink:directly_physically_interacts_with",
-                    sources=build_association_knowledge_sources(primary=INFORES_SIGNOR),
+                    sources=SIGNOR_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                     qualified_predicate = BIOLINK_CAUSES,
@@ -374,7 +376,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     id=entity_id(),
                     subject=subject.id,
                     object=object.id,
-                    sources=build_association_knowledge_sources(primary=INFORES_SIGNOR),
+                    sources=SIGNOR_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                     ## five edge attributes in order
@@ -410,7 +412,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     id=entity_id(),
                     subject=subject.id,
                     object=object.id,
-                    sources=build_association_knowledge_sources(primary=INFORES_SIGNOR),
+                    sources=SIGNOR_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                     ## five edge attributes
@@ -447,7 +449,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     id=entity_id(),
                     subject=subject.id,
                     object=object.id,
-                    sources=build_association_knowledge_sources(primary=INFORES_SIGNOR),
+                    sources=SIGNOR_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                     ## five edge attributes in order
@@ -466,7 +468,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     subject=subject.id,
                     object=object.id,
                     predicate = "biolink:directly_physically_interacts_with",
-                    sources=build_association_knowledge_sources(primary=INFORES_SIGNOR),
+                    sources=SIGNOR_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                     qualified_predicate = BIOLINK_CAUSES,
@@ -500,7 +502,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     id=entity_id(),
                     subject=subject.id,
                     object=object.id,
-                    sources=build_association_knowledge_sources(primary=INFORES_SIGNOR),
+                    sources=SIGNOR_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                     ## five edge attributes in order
@@ -539,7 +541,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     id=entity_id(),
                     subject=subject.id,
                     object=object.id,
-                    sources=build_association_knowledge_sources(primary=INFORES_SIGNOR),
+                    sources=SIGNOR_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                     ## five edge attributes in order
@@ -558,7 +560,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     subject=subject.id,
                     object=object.id,
                     predicate = "biolink:directly_physically_interacts_with",
-                    sources=build_association_knowledge_sources(primary=INFORES_SIGNOR),
+                    sources=SIGNOR_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                     qualified_predicate = BIOLINK_CAUSES,
@@ -592,7 +594,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     id=entity_id(),
                     subject=subject.id,
                     object=object.id,
-                    sources=build_association_knowledge_sources(primary=INFORES_SIGNOR),
+                    sources=SIGNOR_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                     ## five edge attributes in order
@@ -633,7 +635,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     subject=subject.id,
                     object=object.id,
                     predicate = current_predicate_mapping,
-                    sources=build_association_knowledge_sources(primary=INFORES_SIGNOR),
+                    sources=SIGNOR_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                     ## additional species and anatomical_context qualifiers if existing in the current association type
@@ -649,7 +651,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     subject=subject.id,
                     object=object.id,
                     predicate = "biolink:directly_physically_interacts_with",
-                    sources=build_association_knowledge_sources(primary=INFORES_SIGNOR),
+                    sources=SIGNOR_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                 )
@@ -677,7 +679,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     subject=subject.id,
                     object=object.id,
                     predicate = current_predicate_mapping,
-                    sources=build_association_knowledge_sources(primary=INFORES_SIGNOR),
+                    sources=SIGNOR_SOURCES,
                     knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                     agent_type=AgentTypeEnum.manual_agent,
                     ## additional species and anatomical_context qualifiers if existing in the current association type

--- a/src/translator_ingest/ingests/signor/signor.py
+++ b/src/translator_ingest/ingests/signor/signor.py
@@ -23,7 +23,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     KnowledgeLevelEnum,
     AgentTypeEnum,
 )
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from koza.model.graphs import KnowledgeGraph
 from translator_ingest.util.biolink import (
     INFORES_SIGNOR

--- a/src/translator_ingest/ingests/tmkp/tmkp.py
+++ b/src/translator_ingest/ingests/tmkp/tmkp.py
@@ -37,7 +37,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     AgentTypeEnum,
     ChemicalOrGeneOrGeneProductFormOrVariantEnum,
 )
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.biolink import INFORES_TEXT_MINING_KP, get_biolink_model_toolkit
 
 

--- a/src/translator_ingest/ingests/tmkp/tmkp.py
+++ b/src/translator_ingest/ingests/tmkp/tmkp.py
@@ -41,6 +41,11 @@ from translator_ingest.util.biolink import build_association_knowledge_sources
 from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.biolink import INFORES_TEXT_MINING_KP, get_biolink_model_toolkit
 
+TMKP_DEFAULT_SOURCES = build_association_knowledge_sources(
+    primary=INFORES_TEXT_MINING_KP,
+    supporting=["infores:pubmed"],
+)
+
 
 # Remap predicates from source to canonical Biolink form.
 # Text-mined 'treats' edges should use the broader 'treats_or_applied_or_studied_to_treat'
@@ -466,10 +471,7 @@ def transform_tmkp_edge(koza_transform: koza.KozaTransform, record: Dict[str, An
         parse_attributes(attributes, association)
     else:
         # No attributes - set default sources
-        association.sources = build_association_knowledge_sources(
-            primary=INFORES_TEXT_MINING_KP,
-            supporting=["infores:pubmed"]
-        )
+        association.sources = TMKP_DEFAULT_SOURCES
 
     # Create nodes for subject and object
     nodes = []

--- a/src/translator_ingest/ingests/ttd/ttd.py
+++ b/src/translator_ingest/ingests/ttd/ttd.py
@@ -3,7 +3,7 @@ import koza
 import pandas as pd
 from typing import Any, Iterable, Dict, Union
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id
+from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.biolink import INFORES_TTD
 from translator_ingest.util.http_utils import get_modify_date
 from biolink_model.datamodel.pydanticmodel_v2 import (

--- a/src/translator_ingest/ingests/ubergraph/ubergraph.py
+++ b/src/translator_ingest/ingests/ubergraph/ubergraph.py
@@ -18,6 +18,7 @@ from translator_ingest.util.biolink import build_association_knowledge_sources
 from translator_ingest.util.transform_utils import entity_id
 
 INFORES_UBERGRAPH = "infores:ubergraph"
+UBERGRAPH_SOURCES = build_association_knowledge_sources(primary=INFORES_UBERGRAPH)
 
 EXTRACTED_ONTOLOGY_PREFIXES = [
     "UBERON",
@@ -204,8 +205,7 @@ def transform_redundant_graph(koza: koza.KozaTransform, data: Iterable[dict[str,
     nodes_seen = set()
     nodes_batch = []
     edges_batch = []
-    sources = build_association_knowledge_sources(primary=INFORES_UBERGRAPH)
-    
+
     batch_count = 0
     
     for record in data:
@@ -243,7 +243,7 @@ def transform_redundant_graph(koza: koza.KozaTransform, data: Iterable[dict[str,
             subject=subject_curie,
             predicate=predicate_curie,
             object=object_curie,
-            sources=sources,
+            sources=UBERGRAPH_SOURCES,
             knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
             agent_type=AgentTypeEnum.manual_agent,
         ))

--- a/src/translator_ingest/ingests/ubergraph/ubergraph.py
+++ b/src/translator_ingest/ingests/ubergraph/ubergraph.py
@@ -14,7 +14,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     AgentTypeEnum,
 )
 from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import entity_id, build_association_knowledge_sources
+from translator_ingest.util.biolink import build_association_knowledge_sources
+from translator_ingest.util.transform_utils import entity_id
 
 INFORES_UBERGRAPH = "infores:ubergraph"
 

--- a/src/translator_ingest/util/biolink.py
+++ b/src/translator_ingest/util/biolink.py
@@ -1,13 +1,13 @@
 """Biolink Model support for Translator Ingests"""
-from typing import Optional
+from typing import Optional, Union
 from functools import lru_cache
 from importlib.resources import files
 
 from linkml_runtime.utils.schemaview import SchemaView
 
-from biolink_model.datamodel.pydanticmodel_v2 import RetrievalSource
+from biolink_model.datamodel.pydanticmodel_v2 import RetrievalSource, ResourceRoleEnum
+
 from bmt import Toolkit
-from bmt.pydantic import entity_id
 
 from translator_ingest.util.logging_utils import get_logger
 logger = get_logger(__name__)
@@ -126,10 +126,119 @@ def knowledge_sources_from_trapi(source_list: Optional[list[dict]] ) -> Optional
         source: dict
         for source in source_list:
             rs = RetrievalSource(
-                id=entity_id(),
+                id=source["resource_id"],
                 resource_id=source["resource_id"],
                 resource_role=source["resource_role"],
                 upstream_resource_ids=source.get("upstream_resource_ids", None)
             )
             sources.append(rs)
         return sources
+
+
+def _build_retrieval_source(
+        source_spec: Union[str,tuple[str, list[str]]],
+        resource_role: Optional[ResourceRoleEnum]
+) -> RetrievalSource:
+    if isinstance(source_spec, tuple):
+        assert len(source_spec) == 2, f"Invalid supporting data source tuple: {source_spec}"
+        resource_id = str(source_spec[0])
+        source_record_urls = source_spec[1] if len(source_spec[1]) > 0 else None
+    else:
+        resource_id = source_spec
+        source_record_urls = None
+    return RetrievalSource(
+        id=resource_id,
+        resource_id=resource_id,
+        resource_role=resource_role,
+        source_record_urls=source_record_urls,
+        **{},
+    )
+
+def build_association_knowledge_sources(
+        primary: Union[str,tuple[str, list[str]]],
+        supporting: Optional[list[Union[str,tuple[str, list[str]]]]] = None,
+        aggregating: Optional[Union[str,tuple[str, list[str]]]] = None
+) -> list[RetrievalSource]:
+    """
+    This function attempts to build a list of a well-formed RetrievalSource list
+    for an Association **sources** slot, using given knowledge source parameters
+    for primary, supporting and aggregating knowledge sources.
+
+    The use case for 'aggregating knowledge source' represents the limited use case where
+    only one primary knowledge source is specified, as a single upstream knowledge source.
+    This is, of course, not the general case for all aggregating knowledge sources;
+    however, the use case of aggregating knowledge sources with multiple upstream ('primary')
+    knowledge sources is not yet supported.
+
+    This method is lenient in that it allows for strings that are not explicitly encoded
+    as infores identifiers, converting these to infores identifiers by prefixing with
+    the 'infores:' namespace (but the method doesn't validate these coerced infores identifiers
+    against the public infores inventory at https://github.com/biolink/information-resource-registry).
+
+    There are optional 'extended form' provisions for the addition of associated **source_record_urls**
+    to the instances of **resource_id** provided for primary, aggregating and supporting knowledge sources.
+
+    Parameters
+    ----------
+    primary:
+        **Simple form:** Infores 'resource_id' for the primary knowledge source of an Association.
+        **Extended form:** 2-tuple of (resource_id, list[source_record_urls])
+        for the primary knowledge source of an Association.
+
+    supporting:
+        **Simple form:** List of supporting datasource infores 'resource_id' instances. Supporting
+        data sources are automatically assumed to be upstream of the primary knowledge source and
+        mapped accordingly.
+        **Extended form:** List of 2-tuples with form (resource_id, list[source_record_urls]).
+
+    aggregating:
+        **Simple form:** With the infores 'resource_id' of the aggregating knowledge source.
+        The primary knowledge source given to the method is automatically assumed to be upstream
+        of the aggregating knowledge source and mapped accordingly.
+        **Extended form:** 2-tuple of (resource_id, list[source_record_urls])
+        for the aggregating knowledge source of an Association.
+
+    Returns
+    -------
+    list[RetrievalSource]:
+        List of RetrievalSource entries that are not guaranteed in any given order,
+        except that the first entry will usually be the primary knowledge source.
+
+    """
+    primary_knowledge_source: Optional[RetrievalSource] = \
+        _build_retrieval_source(
+            primary,
+            ResourceRoleEnum.primary_knowledge_source
+        )
+    sources: list[RetrievalSource] =[primary_knowledge_source]
+
+    if supporting:
+        for supporting_source_id in supporting:
+            supporting_knowledge_source = \
+                _build_retrieval_source(
+                    supporting_source_id,
+                    ResourceRoleEnum.supporting_data_source
+            )
+            sources.append(supporting_knowledge_source)
+            if primary_knowledge_source.upstream_resource_ids is None:
+                primary_knowledge_source.upstream_resource_ids = []
+            primary_knowledge_source.upstream_resource_ids.append(
+                supporting_knowledge_source.resource_id
+            )
+
+    if aggregating:
+        aggregating_knowledge_source = \
+            _build_retrieval_source(
+                aggregating,
+                ResourceRoleEnum.aggregator_knowledge_source
+            )
+
+        # The use case for 'aggregating knowledge source' represents the
+        # limited use case where only one primary knowledge source is specified
+        aggregating_knowledge_source.upstream_resource_ids = [
+            primary_knowledge_source.resource_id
+        ]
+
+        sources.append(aggregating_knowledge_source)
+
+    return sources

--- a/src/translator_ingest/util/transform_utils.py
+++ b/src/translator_ingest/util/transform_utils.py
@@ -1,0 +1,12 @@
+from uuid import uuid4
+
+def entity_id() -> str:
+    """
+    Generate a unique edge identifier for translator KGs.
+
+    Returns
+    -------
+    str
+        unique uuid identifier
+    """
+    return str(uuid4())

--- a/uv.lock
+++ b/uv.lock
@@ -323,7 +323,7 @@ requires-dist = [
     { name = "polars", specifier = ">=1.35.2" },
     { name = "psycopg", extras = ["binary"] },
     { name = "requests" },
-    { name = "robokop-orion", specifier = "==1.3.2" },
+    { name = "robokop-orion", specifier = "==1.3.3" },
     { name = "uv-dynamic-versioning", specifier = ">=0.11.2" },
     { name = "xmltodict", specifier = ">=1.0.2" },
     { name = "zstandard", specifier = ">=0.25.0" },
@@ -3302,7 +3302,7 @@ wheels = [
 
 [[package]]
 name = "robokop-orion"
-version = "1.3.2"
+version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bmt" },
@@ -3316,9 +3316,9 @@ dependencies = [
     { name = "uuid-utils" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/b4/803f40961479e28d2a3c5becaaaf3ad8f4832a55133e864fb66cd5fce68b/robokop_orion-1.3.2.tar.gz", hash = "sha256:48c91765b84c7647aa20c9481dba55aae3355bc48ae33114790b1cc833018de3", size = 94900, upload-time = "2026-04-22T06:12:11.348Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/53/cb7b2a62397299ca05513f2bbfdc7c1e2cdd488694fe25a92a171e267adb/robokop_orion-1.3.3.tar.gz", hash = "sha256:77cdceaef5f4f7a93828859dc613df7a736397ab75ac7647f8b8725c3ac3d218", size = 94876, upload-time = "2026-04-29T05:21:02.077Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/b5/43a1b31451287525f7cd530bf96c1813e3a1df574be2d542708220b6ce12/robokop_orion-1.3.2-py3-none-any.whl", hash = "sha256:e26871a1081a0e1b516d0c7ec4c8792ea0f26f95794998c8b3058c0ec1698c4d", size = 111045, upload-time = "2026-04-22T06:12:12.468Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/23/d8ed9e246dede1179ad361137f2c69e498e214f9ac36e3a5a1f85e0f5742/robokop_orion-1.3.3-py3-none-any.whl", hash = "sha256:1a5cd9e5f12546e017bca322140b5bf9e2a4cedab848048129360e6d34b102b2", size = 110996, upload-time = "2026-04-29T05:21:00.618Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This does a few things to standardize Association identifiers and significantly increases the efficiency of assigning "sources" to Associations.

**Association IDs**
- Converted all ingests to use the same entity_id() function for Association identifiers, unless they utilize upstream identifiers. This was just a few, most already used it.
- Moved the entity_id() function from bmt to our repo.
- The entity_id() function and ORION assigned ids no longer use the "urn:uuid:" prefix.

**Sources/RetrievalSources**
- Moved the build_association_knowledge_sources and _build_retrieval_source functions from bmt to translator-ingests (probably temporarily) to alter their behavior while we settle on a permanent solution in biolink/bmt. When we do that it will be easy to change the imports back if we want this functionality to live in bmt. All I changed was how RetrievalSource ids are assigned.
- No longer set any RetrievalSource identifiers to random uuids which is inefficient and unnecessary (especially setting a different one for each instance). Instead set them to be the same as the resource_id, as some ingests already did.
- For most ingests, no longer instantiate new RetrievalSource pydantic objects for every edge. Just create one sources list at the module level and use it repeatedly.
- Note that a few ingests create RetrievalSources based on values from their source data and so they were not converted to the one-instantiation paradigm, but they were still converted to use resource_id as the id instead of a uuid when they create RetrievalSource objects without the helper function.

**Misc**
- With the ORION version bump for "uurn:uuid:", I also included removing a misleading log error from ORION ("get_merged_entities called but no file_paths were provided! Empty source?") that was not an indicator of an issue for translator's usage.