### PR TITLE
update biolink to latest master, with fixes for failing tests after linkml update.

### DIFF
--- a/src/translator_ingest/ingests/hpoa/hpoa.py
+++ b/src/translator_ingest/ingests/hpoa/hpoa.py
@@ -25,7 +25,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     PhenotypicFeature,
     DiseaseToPhenotypicFeatureAssociation,
     CausalGeneToDiseaseAssociation,
-    CorrelatedGeneToDiseaseAssociation,
+    GeneToDiseaseAssociation,
     ChemicalOrGeneOrGeneProductFormOrVariantEnum as VE,
     GeneToPhenotypicFeatureAssociation,
     KnowledgeLevelEnum,
@@ -278,7 +278,7 @@ def transform_gene_to_disease_record(
             **{},
         )
     elif qualified_predicate == "biolink:contributes_to":
-        association = CorrelatedGeneToDiseaseAssociation(
+        association = GeneToDiseaseAssociation(
             id=entity_id(),
             subject=gene_id,
             predicate="biolink:associated_with",

--- a/src/translator_ingest/ingests/semmeddb/semmeddb.py
+++ b/src/translator_ingest/ingests/semmeddb/semmeddb.py
@@ -18,8 +18,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     Disease,
     Gene,
     GeneAffectsChemicalAssociation,
+    GeneToGeneAssociation,
     GeneToPhenotypicFeatureAssociation,
-    GeneRegulatesGeneAssociation,
     KnowledgeLevelEnum,
     NamedThing,
     PhenotypicFeature,
@@ -299,7 +299,7 @@ def _pick_affects_class(
     if sub_is_gene and obj_is_chem:
         return GeneAffectsChemicalAssociation
     if sub_is_gene and obj_is_gene:
-        return GeneRegulatesGeneAssociation
+        return GeneToGeneAssociation
     return ChemicalAffectsBiologicalEntityAssociation
 
 

--- a/src/translator_ingest/ingests/semmeddb/semmeddb_rig.yaml
+++ b/src/translator_ingest/ingests/semmeddb/semmeddb_rig.yaml
@@ -230,7 +230,7 @@ target_info:
         - biolink:GeneToPhenotypicFeatureAssociation
         - biolink:ChemicalAffectsGeneAssociation
         - biolink:GeneAffectsChemicalAssociation
-        - biolink:GeneRegulatesGeneAssociation
+        - biolink:GeneToGeneAssociation
         - biolink:ChemicalAffectsBiologicalEntityAssociation
       notes:
         - "Supporting text snippets are retained in has_supporting_studies -> has_study_results -> supporting_text; there is no top-level supporting_text edge property."

--- a/src/translator_ingest/ingests/tmkp/tmkp.py
+++ b/src/translator_ingest/ingests/tmkp/tmkp.py
@@ -11,7 +11,7 @@ Data comes as tar.gz archives containing:
 
 import json
 from functools import lru_cache
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple, Type, get_args
 from loguru import logger
 from bmt.utils import parse_name
 import koza
@@ -28,9 +28,9 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     NamedThing,
     Association,
     ChemicalAffectsGeneAssociation,
-    CorrelatedGeneToDiseaseAssociation,
+    GeneToDiseaseAssociation,
     ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation,
-    GeneRegulatesGeneAssociation,
+    GeneToGeneAssociation,
     Study,
     TextMiningStudyResult,
     KnowledgeLevelEnum,
@@ -88,9 +88,9 @@ BIOLINK_CLASS_MAP = {
 # Map edge types to association classes
 ASSOCIATION_MAP = {
     "biolink:ChemicalToGeneAssociation": ChemicalAffectsGeneAssociation,
-    "biolink:GeneToDiseaseAssociation": CorrelatedGeneToDiseaseAssociation,
+    "biolink:GeneToDiseaseAssociation": GeneToDiseaseAssociation,
     "biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation": ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation,
-    "biolink:GeneRegulatoryRelationship": GeneRegulatesGeneAssociation,
+    "biolink:GeneRegulatoryRelationship": GeneToGeneAssociation,
 }
 
 # Track edges skipped due to invalid subject/object prefixes (for reporting)
@@ -438,31 +438,11 @@ def transform_tmkp_edge(koza_transform: koza.KozaTransform, record: Dict[str, An
     # as defaults: primary predicate 'affects', qualified predicate 'contributes_to', with
     # subject_form_or_variant_qualifier defaulting to 'modified_form' if not already set
     # by the source data (which may provide e.g. 'loss_of_function_variant_form').
-    if (
-        assoc_class == CorrelatedGeneToDiseaseAssociation
-        and predicate == "biolink:contributes_to"
-    ):
+    if assoc_class == GeneToDiseaseAssociation and predicate == "biolink:contributes_to":
         assoc_kwargs["predicate"] = "biolink:affects"
         assoc_kwargs.setdefault("qualified_predicate", "biolink:contributes_to")
         assoc_kwargs.setdefault("subject_form_or_variant_qualifier", MODIFIED_FORM)
 
-    # For GeneRegulatesGeneAssociation, default qualified_predicate to the predicate if not set
-    if assoc_class == GeneRegulatesGeneAssociation and "qualified_predicate" not in assoc_kwargs:
-        assoc_kwargs["qualified_predicate"] = predicate
-
-    # For GeneRegulatesGeneAssociation, require object_aspect_qualifier and object_direction_qualifier.
-    if assoc_class == GeneRegulatesGeneAssociation:
-        # If either qualifier is missing, skip the edge to avoid semantic errors.
-        if "object_aspect_qualifier" not in assoc_kwargs or "object_direction_qualifier" not in assoc_kwargs:
-            logger.warning(
-                "Skipping GeneRegulatesGeneAssociation edge due to missing qualifiers: "
-                f"object_aspect_qualifier={assoc_kwargs.get('object_aspect_qualifier')}, "
-                f"object_direction_qualifier={assoc_kwargs.get('object_direction_qualifier')}. "
-                "These qualifiers are required for semantic correctness."
-            )
-            return None
-
-    # Create association with all fields
     association = assoc_class(**assoc_kwargs)
 
     # Parse attributes JSON - this populates has_supporting_studies and sources on the association

--- a/src/translator_ingest/ingests/tmkp/tmkp.py
+++ b/src/translator_ingest/ingests/tmkp/tmkp.py
@@ -11,7 +11,7 @@ Data comes as tar.gz archives containing:
 
 import json
 from functools import lru_cache
-from typing import Any, Dict, List, Set, Tuple, Type, get_args
+from typing import Any, Dict, List, Set, Tuple
 from loguru import logger
 from bmt.utils import parse_name
 import koza

--- a/src/translator_ingest/ingests/tmkp/tmkp_rig.yaml
+++ b/src/translator_ingest/ingests/tmkp/tmkp_rig.yaml
@@ -53,10 +53,6 @@ ingest_info:
     - file_name: edges.tsv
       filtered_records: Edges where subject/object ID prefixes violate Biolink Model domain/range constraints. For example, edges like "MONDO:xxx biolink:treats DRUGBANK:yyy" are excluded because the association type expects chemicals as subjects and diseases as objects, not the reverse.
       rationale: "Validation uses BMT to dynamically determine valid ID prefixes for each predicate's domain/range constraints, filtering out semantically invalid edges such as reversed ChemicalToDiseaseOrPhenotypicFeatureAssociation edges where diseases/phenotypes (MONDO, HP prefixes) are incorrectly positioned as subjects."
-    - file_name: edges.tsv
-      filtered_records: GeneRegulatesGeneAssociation edges that lack required qualifiers (object_aspect_qualifier or object_direction_qualifier).
-      rationale: "These qualifiers are required for semantic correctness of regulatory relationships. Edges without them would have ambiguous meaning."
-
   transformed_content:
     - file_name: edges.tsv
       transformation: "Predicate remap: 'biolink:treats' → 'biolink:treats_or_applied_or_studied_to_treat'"
@@ -168,15 +164,15 @@ target_info:
         - "biolink:evidence_count"
         - "biolink:has_confidence_score"
       ui_explanation: |
-        Targeted text mining identified gene regulatory relationships where one protein causes
-        changes in another protein's activity or abundance. These edges include required qualifiers
-        indicating the direction and magnitude of the regulatory effect.
+        Targeted text mining identified gene regulatory relationships where one protein affects
+        another protein's activity or abundance. When present, qualifiers indicate the causal
+        direction and the aspect/direction of the regulatory effect.
       source_files:
         - edges.tsv
       additional_notes: |
-        Association type: GeneRegulatesGeneAssociation. Requires object_aspect_qualifier and
-        object_direction_qualifier for semantic correctness. Edges lacking these qualifiers are
-        filtered out during processing. All source edges provide qualified_predicate='biolink:causes'.
+        Association type: GeneToGeneAssociation. Predicate is 'biolink:affects' with optional
+        qualified_predicate='biolink:causes' and object_aspect_qualifier/object_direction_qualifier
+        passed through from the source data when provided.
 
     - subject_categories:
         - "biolink:SmallMolecule"
@@ -286,7 +282,7 @@ target_info:
       source_files:
         - edges.tsv
       additional_notes: |
-        Association type: CorrelatedGeneToDiseaseAssociation. Two code paths produce these edges:
+        Association type: GeneToDiseaseAssociation. Two code paths produce these edges:
         (1) Source predicate 'biolink:contributes_to' is transformed to the canonical EPC pattern
         with subject_form_or_variant_qualifier defaulting to 'modified_form'. (2) Source edges
         that already arrive with predicate='biolink:affects' and qualified_predicate=
@@ -319,11 +315,7 @@ target_info:
       source_files:
         - edges.tsv
       additional_notes: |
-        Association type: CorrelatedGeneToDiseaseAssociation. The code uses
-        CorrelatedGeneToDiseaseAssociation rather than GeneToDiseaseAssociation because
-        the base GeneToDiseaseAssociation constrains predicates to only 'contributes_to'
-        or 'associated_with', and does not support 'affects' which is used by TMKP
-        for gene-disease edges.
+        Association type: GeneToDiseaseAssociation.
 
   node_type_info:
     - node_category: "biolink:ChemicalEntity"

--- a/tests/unit/ingests/hpoa/test_hpoa.py
+++ b/tests/unit/ingests/hpoa/test_hpoa.py
@@ -354,7 +354,7 @@ def test_predicate(association: str, expected_predicate: Optional[str]):
             ],
             # Captured edge contents
             {
-                "category": ["biolink:CorrelatedGeneToDiseaseAssociation"],
+                "category": ["biolink:GeneToDiseaseAssociation"],
                 "subject": "NCBIGene:6505",
                 "predicate": "biolink:associated_with",
                 "object": "OMIM:615232",

--- a/tests/unit/ingests/semmeddb/test_semmeddb.py
+++ b/tests/unit/ingests/semmeddb/test_semmeddb.py
@@ -9,8 +9,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     Disease,
     Gene,
     GeneAffectsChemicalAssociation,
+    GeneToGeneAssociation,
     GeneToPhenotypicFeatureAssociation,
-    GeneRegulatesGeneAssociation,
     KnowledgeLevelEnum,
     NamedThing,
     Protein,
@@ -226,7 +226,7 @@ def test_qualifier_gene_affects_chemical():
 
 
 def test_qualifier_gene_affects_gene():
-    """Gene subject + Gene object with qualifiers -> GeneRegulatesGeneAssociation."""
+    """Gene subject + Gene object with qualifiers -> GeneToGeneAssociation."""
     record = _base_record(
         subject="NCBIGene:100",
         object="HGNC:200",
@@ -237,8 +237,11 @@ def test_qualifier_gene_affects_gene():
     )
     entities = _create_test_runner(record)
     assoc = [e for e in entities if isinstance(e, Association)][0]
-    assert isinstance(assoc, GeneRegulatesGeneAssociation)
+    assert isinstance(assoc, GeneToGeneAssociation)
+    assert assoc.predicate == "biolink:affects"
+    assert assoc.qualified_predicate == "biolink:causes"
     assert assoc.object_aspect_qualifier == "activity_or_abundance"
+    assert assoc.object_direction_qualifier == "increased"
 
 
 def test_qualifier_fallback_named_thing():

--- a/tests/unit/ingests/tmkp/test_tmkp.py
+++ b/tests/unit/ingests/tmkp/test_tmkp.py
@@ -8,8 +8,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     Association,
     ChemicalAffectsGeneAssociation,
     ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation,
-    CorrelatedGeneToDiseaseAssociation,
-    GeneRegulatesGeneAssociation,
+    GeneToDiseaseAssociation,
+    GeneToGeneAssociation,
     KnowledgeLevelEnum,
     AgentTypeEnum,
     NamedThing,
@@ -505,8 +505,8 @@ class TestTransformTmkpEdge:
         associations = [i for i in items if isinstance(i, Association)]
         assert len(associations) == 0
 
-    def test_gene_regulates_gene_without_qualifiers_is_skipped(self):
-        """GeneRegulatesGeneAssociation without required qualifiers is skipped."""
+    def test_gene_to_gene_without_qualifiers(self):
+        """GeneToGeneAssociation is emitted even without typed qualifiers (qualifiers are optional)."""
         record = {
             "subject": "NCBIGene:100",
             "predicate": "biolink:affects",
@@ -516,15 +516,21 @@ class TestTransformTmkpEdge:
         items = _run_edge_transform(record)
 
         associations = [i for i in items if isinstance(i, Association)]
-        assert len(associations) == 0
+        assert len(associations) == 1
+        assert isinstance(associations[0], GeneToGeneAssociation)
+        assert associations[0].predicate == "biolink:affects"
+        assert associations[0].qualified_predicate is None
+        assert associations[0].object_aspect_qualifier is None
+        assert associations[0].object_direction_qualifier is None
 
-    def test_gene_regulates_gene_with_qualifiers(self):
-        """GeneRegulatesGeneAssociation succeeds when required qualifiers are present."""
+    def test_gene_to_gene_with_qualifiers(self):
+        """GeneToGeneAssociation passes through source qualifiers without altering predicate."""
         record = {
             "subject": "NCBIGene:100",
             "predicate": "biolink:affects",
             "object": "NCBIGene:200",
             "relation": "biolink:GeneRegulatoryRelationship",
+            "qualified_predicate": "biolink:causes",
             "object_aspect_qualifier": "activity_or_abundance",
             "object_direction_qualifier": "increased",
         }
@@ -532,26 +538,54 @@ class TestTransformTmkpEdge:
 
         associations = [i for i in items if isinstance(i, Association)]
         assert len(associations) == 1
-        assert isinstance(associations[0], GeneRegulatesGeneAssociation)
+        assert isinstance(associations[0], GeneToGeneAssociation)
+        assert associations[0].predicate == "biolink:affects"
+        assert associations[0].qualified_predicate == "biolink:causes"
         assert associations[0].object_aspect_qualifier == "activity_or_abundance"
         assert associations[0].object_direction_qualifier == "increased"
 
     @pytest.mark.parametrize(
-        "relation,expected_class",
+        "record,expected_class",
         [
-            ("biolink:ChemicalToGeneAssociation", ChemicalAffectsGeneAssociation),
-            ("biolink:GeneToDiseaseAssociation", CorrelatedGeneToDiseaseAssociation),
-            ("biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation", ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation),
+            (
+                {
+                    "subject": "DRUGBANK:DB01248",
+                    "predicate": "biolink:affects",
+                    "object": "UniProtKB:P12345",
+                    "relation": "biolink:ChemicalToGeneAssociation",
+                    "object_aspect_qualifier": "activity_or_abundance",
+                    "object_direction_qualifier": "increased",
+                },
+                ChemicalAffectsGeneAssociation,
+            ),
+            (
+                {
+                    "subject": "HGNC:11477",
+                    "predicate": "biolink:associated_with",
+                    "object": "MONDO:0005148",
+                    "relation": "biolink:GeneToDiseaseAssociation",
+                },
+                GeneToDiseaseAssociation,
+            ),
+            (
+                {
+                    "subject": "DRUGBANK:DB01248",
+                    "predicate": "biolink:treats",
+                    "object": "MONDO:0008315",
+                    "relation": "biolink:ChemicalToDiseaseOrPhenotypicFeatureAssociation",
+                },
+                ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation,
+            ),
         ],
     )
-    def test_association_class_mapping(self, relation: str, expected_class: type):
-        """Relation maps to the correct Association subclass."""
-        record = {
-            "subject": "DRUGBANK:DB01248",
-            "predicate": "biolink:treats",
-            "object": "MONDO:0008315",
-            "relation": relation,
-        }
+    def test_association_class_mapping(self, record: dict, expected_class: type):
+        """Relation maps to the correct Association subclass.
+
+        Each row uses a subject/predicate/object combination that is consistent
+        with both the declared `relation` and the source data shape. The
+        ChemicalToGene case includes the qualifiers required by
+        ChemicalAffectsGeneAssociation in the Biolink Model.
+        """
         items = _run_edge_transform(record)
 
         associations = [i for i in items if isinstance(i, Association)]
@@ -630,7 +664,7 @@ class TestTransformTmkpEdge:
         assert len(associations) == 1
 
         assoc = associations[0]
-        assert isinstance(assoc, CorrelatedGeneToDiseaseAssociation)
+        assert isinstance(assoc, GeneToDiseaseAssociation)
         assert assoc.predicate == "biolink:affects"
         assert assoc.qualified_predicate == "biolink:contributes_to"
         assert assoc.subject_form_or_variant_qualifier == MODIFIED_FORM
@@ -655,7 +689,7 @@ class TestTransformTmkpEdge:
         assert len(associations) == 1
 
         assoc = associations[0]
-        assert isinstance(assoc, CorrelatedGeneToDiseaseAssociation)
+        assert isinstance(assoc, GeneToDiseaseAssociation)
         assert assoc.predicate == "biolink:affects"
         assert assoc.qualified_predicate == "biolink:contributes_to"
         assert assoc.subject_form_or_variant_qualifier == "loss_of_function_variant_form"
@@ -691,7 +725,7 @@ class TestTransformTmkpEdge:
         assert len(associations) == 1
 
         assoc = associations[0]
-        assert isinstance(assoc, CorrelatedGeneToDiseaseAssociation)
+        assert isinstance(assoc, GeneToDiseaseAssociation)
         assert assoc.predicate == "biolink:affects"
         assert not hasattr(assoc, "qualified_predicate") or assoc.qualified_predicate is None
 
@@ -715,7 +749,7 @@ class TestTransformTmkpEdge:
         assert len(associations) == 1
 
         assoc = associations[0]
-        assert isinstance(assoc, CorrelatedGeneToDiseaseAssociation)
+        assert isinstance(assoc, GeneToDiseaseAssociation)
         assert assoc.predicate == "biolink:affects"
         assert assoc.qualified_predicate == "biolink:contributes_to"
         assert assoc.subject_form_or_variant_qualifier == "loss_of_function_variant_form"

--- a/uv.lock
+++ b/uv.lock
@@ -166,8 +166,8 @@ wheels = [
 
 [[package]]
 name = "biolink-model"
-version = "4.3.7.post16.dev0+c40133f62"
-source = { git = "https://github.com/biolink/biolink-model.git?rev=master#c40133f626408dbd6250a220df3b3d10659449a2" }
+version = "4.4.0rc2"
+source = { git = "https://github.com/biolink/biolink-model.git?rev=master#84519eec8c20650ea887429b9cce45c4a44aacad" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "click" },
@@ -1727,7 +1727,7 @@ wheels = [
 
 [[package]]
 name = "linkml"
-version = "1.9.4"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antlr4-python3-runtime" },
@@ -1755,14 +1755,14 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/7c/ea1548762bf9098d7a50925579318d1f773a97b2666c8eaa397321afe242/linkml-1.9.4.tar.gz", hash = "sha256:b5075a697bfdb6ef829e19e15046f6efc11a946352eb7f5024e89f710ebd96ca", size = 42799474, upload-time = "2025-08-26T18:07:49.725Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/57/e480d016c94ac1dcfeccde3fd751fa1464545e3de2446c9ebf9fe66dd393/linkml-1.10.0.tar.gz", hash = "sha256:ca70bba1474bc7de37edd33005a8a556d4718190584ab2c88f7c46d090477d55", size = 334216, upload-time = "2026-02-25T17:13:32.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/bd/e46587d1c99334c708d485c7a357ee58de13e2348881917829001d7a11ac/linkml-1.9.4-py3-none-any.whl", hash = "sha256:ecc5cb73669da7d48340f689ae6ed8076b6b15099aef472668345fc9b5931b11", size = 337157, upload-time = "2025-08-26T18:07:47.205Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/54/0d01e407b3b8657cb1a58031e3f23e7039d26338173a130a3be30fdd8e0b/linkml-1.10.0-py3-none-any.whl", hash = "sha256:2d4934f000977489352307336267a8a4270de3156187c3394d542a0a4b8130e5", size = 434438, upload-time = "2026-02-25T17:13:29.068Z" },
 ]
 
 [[package]]
 name = "linkml-runtime"
-version = "1.9.5"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1779,9 +1779,9 @@ dependencies = [
     { name = "rdflib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/38/38ac19a5b81982f03709cda0a008327dc775d11f008d0cbdc0f2a5389e24/linkml_runtime-1.9.5.tar.gz", hash = "sha256:78dc1383adf11ad5f20bb11b6adde56ed566fbd2429a292d57699ad4596c738a", size = 480288, upload-time = "2025-08-15T22:22:51.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/3d/031e2e8ef7ca872340fb7b7102cfd1fe4a0b329dc04ff694ad9ec6ccaddc/linkml_runtime-1.10.0.tar.gz", hash = "sha256:899889d584ce8056c5c44512b2d247bdc84a8484c3aa228aeb2db283e3a9d2ec", size = 589957, upload-time = "2026-02-25T17:13:34.034Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/28/cdcbe1f0521a98b891dd30249513eef1ddcc7bb406be953b4a8d7825e68f/linkml_runtime-1.9.5-py3-none-any.whl", hash = "sha256:fece3e8aa25a4246165c6528b6a7fe83a929b985d2ce1951cc8a0f4da1a30b90", size = 576405, upload-time = "2025-08-15T22:22:49.264Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/2d/6ab4127bb9aa6e3b54ad5d81fd0c0c12e4d1a80300f2bfdac8f2e18f9d17/linkml_runtime-1.10.0-py3-none-any.whl", hash = "sha256:b7caf806e1b49bf62005d8f398b070c282742c5f6626469fdc1660add0c9da58", size = 584001, upload-time = "2026-02-25T17:13:30.603Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
With upgrade of linkml in biolink-model, we got a more rigorous pydantic generator which then led to downstream test errors in this repo as a result of some edges violating association constraints.  I chose the side of updating the association classes in the model vs. changing any of the edge semantics in our ingests (as those edge semantics have been vetted/qa'd, etc. already).  