### PR TITLE
NCATSTranslator/Feedback/#1213 Addressed

### DIFF
--- a/src/translator_ingest/ingests/semmeddb/semmeddb.py
+++ b/src/translator_ingest/ingests/semmeddb/semmeddb.py
@@ -67,6 +67,24 @@ BTE_EXCLUDED_ORIGINAL_PREDICATES: frozenset[str] = frozenset({
     "lower_than",
 })
 
+# Qualifier aspects that semantically require both endpoints to be activity-
+# or abundance-bearing entities (i.e., Gene, Protein, or ChemicalEntity).
+# Tied to NCATSTranslator/Feedback#1213: KG2 emits chemical -> phenotype/
+# disease/anatomy edges qualified as "causes activity_or_abundance increased",
+# which Aragorn then chains on to produce nonsensical "X has increased
+# activity caused by Y" inferences.
+ACTIVITY_LIKE_ASPECTS: frozenset[str] = frozenset({
+    "activity",
+    "activity_or_abundance",
+    "abundance",
+})
+
+_ACTIVITY_BEARING_CLASSES: frozenset[type[NamedThing]] = frozenset({
+    Gene,
+    Protein,
+    ChemicalEntity,
+})
+
 
 def get_latest_version() -> str:
     """Return the current SemMedDB ingest version identifier."""
@@ -98,6 +116,39 @@ def _is_disease(curie: str) -> bool:
 def _is_phenotypic_feature(curie: str) -> bool:
     """Check whether a CURIE maps to PhenotypicFeature."""
     return _get_node_class(curie) is PhenotypicFeature
+
+
+def _aspect_target_is_valid(
+    subject_id: str,
+    object_id: str,
+    aspect: str | None,
+) -> bool:
+    """Return True if the qualifier aspect is semantically applicable to both endpoints.
+
+    Activity-like aspects (see ``ACTIVITY_LIKE_ASPECTS``) require both subject
+    and object to be Gene, Protein, or ChemicalEntity. Other aspect values
+    (or no aspect) are unconstrained here.
+
+    Per NCATSTranslator/Feedback#1213, KG2 emits some chemical -> non-activity-
+    bearing edges with activity qualifiers (e.g., glucose -> "injury"). Those
+    qualifiers must be stripped so downstream rules cannot treat them as
+    measurable activity changes.
+
+    >>> _aspect_target_is_valid("CHEBI:1", "NCBIGene:1", "activity")
+    True
+    >>> _aspect_target_is_valid("CHEBI:1", "UMLS:C0012345", "activity_or_abundance")
+    False
+    >>> _aspect_target_is_valid("CHEBI:1", "MONDO:1", "activity")
+    False
+    >>> _aspect_target_is_valid("CHEBI:1", "MONDO:1", None)
+    True
+    """
+    if aspect not in ACTIVITY_LIKE_ASPECTS:
+        return True
+    return (
+        _get_node_class(subject_id) in _ACTIVITY_BEARING_CLASSES
+        and _get_node_class(object_id) in _ACTIVITY_BEARING_CLASSES
+    )
 
 
 def _has_bte_excluded_predicate(kg2_ids: list[str]) -> bool:
@@ -244,6 +295,7 @@ _STATE_DEFAULTS: dict[str, int] = {
     "low_publication_count_skipped": 0,
     "bte_excluded_predicate_skipped": 0,
     "publications_capped": 0,
+    "qualifier_stripped_invalid_domain_range": 0,
 }
 
 
@@ -275,6 +327,11 @@ def on_end_filter_edges(koza: koza.KozaTransform) -> None:  # noqa: PLR0912
         ("low_publication_count_skipped", "Low publication count skipped", "INFO"),
         ("bte_excluded_predicate_skipped", "BTE-excluded predicate skipped", "INFO"),
         ("publications_capped", "Publications capped to top-N by score+recency", "INFO"),
+        (
+            "qualifier_stripped_invalid_domain_range",
+            "Qualifier stripped (aspect/endpoint mismatch, see Feedback#1213)",
+            "INFO",
+        ),
     ]
     for key, label, level in _warn_if:
         if s[key] > 0:
@@ -350,16 +407,28 @@ def _build_association(
     subject_id: str,
     object_id: str,
     predicate: str,
+    state: dict[str, Any],
 ) -> Association:
-    """Route to the correct Association subclass and attach qualifiers."""
-    # KG2 field -> Biolink field mapping for qualifiers
+    """Route to the correct Association subclass and attach qualifiers.
+
+    For qualifier triples expressing activity- or abundance-like semantics
+    (``aspect in ACTIVITY_LIKE_ASPECTS``), Biolink-style domain/range applies:
+    both subject and object must be Gene, Protein, or ChemicalEntity. When the
+    check fails, qualifiers are stripped and the edge is emitted as a plain
+    ``biolink:affects`` Association (literature evidence is preserved). See
+    NCATSTranslator/Feedback#1213.
+    """
     qualified_predicate: str | None = record.get("qualified_predicate")
 
     if qualified_predicate:
+        aspect = record.get("qualified_object_aspect")
+        if not _aspect_target_is_valid(subject_id, object_id, aspect):
+            state["qualifier_stripped_invalid_domain_range"] += 1
+            return Association(**association_kwargs)
+
         qualifier_kwargs: dict[str, Any] = {
             "qualified_predicate": qualified_predicate,
         }
-        aspect = record.get("qualified_object_aspect")
         if aspect is not None:
             qualifier_kwargs["object_aspect_qualifier"] = aspect
         direction = record.get("qualified_object_direction")
@@ -449,7 +518,7 @@ def transform_semmeddb_edge(
         koza.state["edges_with_qualifiers"] += 1
 
     association = _build_association(
-        association_kwargs, record, subject_id, object_id, predicate,
+        association_kwargs, record, subject_id, object_id, predicate, koza.state,
     )
 
     supporting_studies = _extract_supporting_studies(publications_info)

--- a/tests/unit/ingests/semmeddb/test_semmeddb.py
+++ b/tests/unit/ingests/semmeddb/test_semmeddb.py
@@ -3,7 +3,6 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     AgentTypeEnum,
     Association,
     CausalGeneToDiseaseAssociation,
-    ChemicalAffectsBiologicalEntityAssociation,
     ChemicalAffectsGeneAssociation,
     ChemicalEntity,
     Disease,
@@ -244,8 +243,14 @@ def test_qualifier_gene_affects_gene():
     assert assoc.object_direction_qualifier == "increased"
 
 
-def test_qualifier_fallback_named_thing():
-    """NamedThing subject + NamedThing object -> ChemicalAffectsBiologicalEntityAssociation."""
+def test_qualifier_stripped_when_endpoints_untyped():
+    """NamedThing-on-both-sides with activity aspect strips the qualifier triple.
+
+    Regression for NCATSTranslator/Feedback#1213. Activity-like aspects are
+    only valid when both endpoints are Gene/Protein/ChemicalEntity, so an
+    untyped subject and object cannot bear them. The edge is downgraded to a
+    plain ``biolink:affects`` Association without qualifier fields.
+    """
     record = _base_record(
         subject="UMLS:C0011847",
         object="UMLS:C0012345",
@@ -256,7 +261,95 @@ def test_qualifier_fallback_named_thing():
     )
     entities = _create_test_runner(record)
     assoc = [e for e in entities if isinstance(e, Association)][0]
-    assert isinstance(assoc, ChemicalAffectsBiologicalEntityAssociation)
+    assert type(assoc) is Association
+    assert assoc.predicate == "biolink:affects"
+    dumped = assoc.model_dump(mode="json", exclude_none=True)
+    assert "qualified_predicate" not in dumped
+    assert "object_aspect_qualifier" not in dumped
+    assert "object_direction_qualifier" not in dumped
+
+
+def test_issue_1213_chemical_to_phenotype_strips_qualifier():
+    """Regression for NCATSTranslator/Feedback#1213.
+
+    The literal failing example from the issue: D-glucose (CHEBI:17234) ->
+    "injury" (UMLS:C3263723) with ``causes activity_or_abundance increased``.
+    Aragorn was chaining the qualifier semantics to produce "X has increased
+    activity caused by glucose" inferences. After this fix, the qualifier
+    triple is stripped so the chain cannot match.
+    """
+    record = _base_record(
+        subject="CHEBI:17234",
+        object="UMLS:C3263723",
+        predicate="biolink:affects",
+        qualified_predicate="biolink:causes",
+        qualified_object_aspect="activity_or_abundance",
+        qualified_object_direction="increased",
+    )
+    entities = _create_test_runner(record)
+    assoc = [e for e in entities if isinstance(e, Association)][0]
+    assert type(assoc) is Association
+    assert assoc.predicate == "biolink:affects"
+    dumped = assoc.model_dump(mode="json", exclude_none=True)
+    assert "qualified_predicate" not in dumped
+    assert "object_aspect_qualifier" not in dumped
+    assert "object_direction_qualifier" not in dumped
+
+
+@pytest.mark.parametrize("subject_id,object_id", [
+    ("CHEBI:15365", "MONDO:0005148"),
+    ("CHEBI:15365", "HP:0000118"),
+    ("CHEBI:15365", "UBERON:0000001"),
+    ("CHEBI:15365", "UMLS:C0012345"),
+    ("UMLS:C0011847", "NCBIGene:100"),
+    ("MONDO:0005148", "CHEBI:15365"),
+])
+def test_activity_qualifier_stripped_for_non_activity_bearing_endpoints(
+    subject_id: str,
+    object_id: str,
+):
+    """Activity-like qualifiers require Gene/Protein/Chemical on BOTH sides."""
+    record = _base_record(
+        subject=subject_id,
+        object=object_id,
+        predicate="biolink:affects",
+        qualified_predicate="biolink:causes",
+        qualified_object_aspect="activity_or_abundance",
+        qualified_object_direction="increased",
+    )
+    entities = _create_test_runner(record)
+    assoc = [e for e in entities if isinstance(e, Association)][0]
+    assert type(assoc) is Association
+    assert assoc.predicate == "biolink:affects"
+    dumped = assoc.model_dump(mode="json", exclude_none=True)
+    assert "qualified_predicate" not in dumped
+    assert "object_aspect_qualifier" not in dumped
+    assert "object_direction_qualifier" not in dumped
+
+
+@pytest.mark.parametrize("subject_id,object_id", [
+    ("CHEBI:15365", "NCBIGene:100"),
+    ("CHEBI:15365", "UniProtKB:P12345"),
+    ("CHEBI:15365", "CHEBI:99999"),
+    ("NCBIGene:100", "CHEBI:15365"),
+    ("NCBIGene:100", "HGNC:200"),
+    ("UniProtKB:P12345", "NCBIGene:100"),
+])
+def test_activity_qualifier_kept_for_activity_bearing_endpoints(
+    subject_id: str,
+    object_id: str,
+):
+    """Activity-like qualifiers pass through when both endpoints are Gene/Protein/Chemical."""
+    record = _base_record(
+        subject=subject_id,
+        object=object_id,
+        predicate="biolink:affects",
+        qualified_predicate="biolink:causes",
+        qualified_object_aspect="activity",
+        qualified_object_direction="increased",
+    )
+    entities = _create_test_runner(record)
+    assoc = [e for e in entities if isinstance(e, Association)][0]
     assert assoc.qualified_predicate == "biolink:causes"
     assert assoc.object_aspect_qualifier == "activity"
     assert assoc.object_direction_qualifier == "increased"


### PR DESCRIPTION
[NCATSTranslator/Feedback/#1213](https://github.com/NCATSTranslator/Feedback/issues/1213)

Strip activity/abundance qualifier triples when endpoints aren't activity-bearing

KG2 emits qualifier triples (qualified_predicate=biolink:causes,
object_aspect_qualifier in {activity, activity_or_abundance, abundance},
object_direction_qualifier in {increased, decreased}) regardless of object
class. 

Aragorn pattern-matches on these and produces nonsense inferences
when the object is a phenotype, disease, anatomy, or untyped UMLS term
("XDH has increased activity caused by glucose" via an "injury" bridge node).

Enforce Biolink-style domain/range at the qualifier-emission layer in
`_build_association()`: both subject and object must be `Gene, Protein, or
ChemicalEntity` for an activity-like qualifier triple to be attached. When
the check fails, strip the triple and emit a plain `biolink:affects` edge.
Literature evidence (publications, supporting studies) is preserved so
non-directional rules retain recall.

New per-run counter qualifier_stripped_invalid_domain_range reports
downgrade volume. Regression test uses the literal CURIEs from the issue
`CHEBI:17234 -> UMLS:C3263723, activity_or_abundance/increased`