### PR TITLE
May run pydantic failure fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "beautifulsoup4>=4.14.2",
-    "biolink-model",
+    "biolink-model==4.4.2",
     "bmt>=1.4.8",
     "click>=8.0.0",
     "codespell>=2.4.1",
@@ -48,7 +48,7 @@ dev = [
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.5.0",
     "mkdocs-minify-plugin>=0.8.0",
-    "biolink-model",
+    "biolink-model==4.4.2",
 ]
 
 [tool.pytest.ini_options]
@@ -65,9 +65,6 @@ target-version = ["py312"]
 
 [tool.uv]
 package = true
-
-[tool.uv.sources]
-biolink-model = { git = "https://github.com/biolink/biolink-model.git", branch = "chembl" }
 
 [tool.uv-dynamic-versioning]
 vcs = "git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "beautifulsoup4>=4.14.2",
-    "biolink-model==4.4.1",
+    "biolink-model",
     "bmt>=1.4.8",
     "click>=8.0.0",
     "codespell>=2.4.1",
@@ -48,7 +48,7 @@ dev = [
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.5.0",
     "mkdocs-minify-plugin>=0.8.0",
-    "biolink-model==4.4.1",
+    "biolink-model",
 ]
 
 [tool.pytest.ini_options]
@@ -65,6 +65,9 @@ target-version = ["py312"]
 
 [tool.uv]
 package = true
+
+[tool.uv.sources]
+biolink-model = { git = "https://github.com/biolink/biolink-model.git", branch = "chembl" }
 
 [tool.uv-dynamic-versioning]
 vcs = "git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "beautifulsoup4>=4.14.2",
-    "biolink-model==4.4.0",
+    "biolink-model==4.4.1",
     "bmt>=1.4.8",
     "click>=8.0.0",
     "codespell>=2.4.1",
@@ -48,7 +48,7 @@ dev = [
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.5.0",
     "mkdocs-minify-plugin>=0.8.0",
-    "biolink-model==4.4.0",
+    "biolink-model==4.4.1",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "beautifulsoup4>=4.14.2",
-    "biolink-model==4.4.0rc3",
+    "biolink-model==4.4.0",
     "bmt>=1.4.8",
     "click>=8.0.0",
     "codespell>=2.4.1",
@@ -48,7 +48,7 @@ dev = [
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.5.0",
     "mkdocs-minify-plugin>=0.8.0",
-    "biolink-model==4.4.0rc3",
+    "biolink-model==4.4.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/translator_ingest/ingests/chembl/chembl.py
+++ b/src/translator_ingest/ingests/chembl/chembl.py
@@ -584,7 +584,7 @@ def get_association(koza, record, action_type_map):
     return nodes,edges
 
 
-def get_activity_association(koza: koza.KozaTransform, chemical, target, action_type_map, record: dict[str, Any]) -> ChemicalAffectsGeneAssociation | GeneAffectsChemicalAssociation | None:
+def get_activity_association(koza: koza.KozaTransform, chemical, target, action_type_map, record: dict[str, Any]) -> bm.Association | None:
     """Build an association for a ChEMBL activity record, respecting the
     direction implied by the association type in *action_type_map*."""
     species_context_qualifier = get_species_context_qualifier(record)

--- a/src/translator_ingest/ingests/chembl/chembl.py
+++ b/src/translator_ingest/ingests/chembl/chembl.py
@@ -13,7 +13,8 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     ChemicalAffectsGeneAssociation,
     GeneAffectsChemicalAssociation,
     ChemicalEntityToChemicalEntityAssociation,
-    AnatomicalEntityHasPartAnatomicalEntityAssociation
+    AnatomicalEntityHasPartAnatomicalEntityAssociation,
+    ChemicalGeneInteractionAssociation,
 )
 
 from koza.model.graphs import KnowledgeGraph
@@ -515,6 +516,8 @@ def get_association_class(association_type: str):
         return ChemicalAffectsGeneAssociation
     if association_type == "GeneAffectsChemicalAssociation":
         return GeneAffectsChemicalAssociation
+    if association_type == "ChemicalGeneInteractionAssociation":
+        return ChemicalGeneInteractionAssociation
     return None
 
 

--- a/src/translator_ingest/ingests/chembl/chembl.py
+++ b/src/translator_ingest/ingests/chembl/chembl.py
@@ -15,6 +15,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     ChemicalEntityToChemicalEntityAssociation,
     AnatomicalEntityHasPartAnatomicalEntityAssociation,
     ChemicalGeneInteractionAssociation,
+    MacromolecularMachineHasSubstrateAssociation,
 )
 
 from koza.model.graphs import KnowledgeGraph
@@ -518,6 +519,8 @@ def get_association_class(association_type: str):
         return GeneAffectsChemicalAssociation
     if association_type == "ChemicalGeneInteractionAssociation":
         return ChemicalGeneInteractionAssociation
+    if association_type == "MacromolecularMachineHasSubstrateAssociation":
+        return MacromolecularMachineHasSubstrateAssociation
     return None
 
 
@@ -545,14 +548,24 @@ def get_association(koza, record, action_type_map):
         if association_class is None:
             koza.log(f" Unknown association class for action type {record['action_type']}", level="WARNING")
             return [], []
-            # Create association
+
+        # For GeneAffectsChemicalAssociation the gene is the subject and
+        # the chemical is the object; the mutation qualifier describes the gene.
+        if association_type == "GeneAffectsChemicalAssociation":
+            subject_id = target.id
+            object_id = chemical.id
+        else:
+            subject_id = chemical.id
+            object_id = target.id
+
         association = association_class(
                 id=entity_id(),
-                subject=chemical.id,
+                subject=subject_id,
                 predicate=predicate,
-                object=target.id,
+                object=object_id,
                 species_context_qualifier = species_context_qualifier,
-                object_form_or_variant_qualifier = mutation_qualifier,
+                subject_form_or_variant_qualifier = mutation_qualifier if association_type == "GeneAffectsChemicalAssociation" else None,
+                object_form_or_variant_qualifier = mutation_qualifier if association_type != "GeneAffectsChemicalAssociation" else None,
                 sources=CHEMBL_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
@@ -572,16 +585,32 @@ def get_association(koza, record, action_type_map):
 
 
 def get_activity_association(koza: koza.KozaTransform, chemical, target, action_type_map, record: dict[str, Any]) -> ChemicalAffectsGeneAssociation | GeneAffectsChemicalAssociation | None:
+    """Build an association for a ChEMBL activity record, respecting the
+    direction implied by the association type in *action_type_map*."""
     species_context_qualifier = get_species_context_qualifier(record)
     anatomical_context_qualifier = record["uberon_id"]
     publications = get_publications(koza, record)
     predicate = action_type_map["predicate"]
+    association_type = action_type_map["association"]
     qualifiers = action_type_map["qualifiers"]
-    association = ChemicalAffectsGeneAssociation(
+
+    association_class = get_association_class(association_type)
+    if association_class is None:
+        koza.log(f" Unknown association class for action type {record['action_type']}", level="WARNING")
+        return None
+
+    if association_type == "GeneAffectsChemicalAssociation":
+        subject_id = target.id
+        object_id = chemical.id
+    else:
+        subject_id = chemical.id
+        object_id = target.id
+
+    association = association_class(
         id=entity_id(),
-        subject=chemical.id,
+        subject=subject_id,
         predicate=predicate,
-        object=target.id,
+        object=object_id,
         species_context_qualifier = species_context_qualifier,
         anatomical_context_qualifier = [anatomical_context_qualifier] if anatomical_context_qualifier else None,
         sources=CHEMBL_SOURCES,

--- a/src/translator_ingest/ingests/chembl/chembl.py
+++ b/src/translator_ingest/ingests/chembl/chembl.py
@@ -549,9 +549,10 @@ def get_association(koza, record, action_type_map):
             koza.log(f" Unknown association class for action type {record['action_type']}", level="WARNING")
             return [], []
 
-        # For GeneAffectsChemicalAssociation the gene is the subject and
-        # the chemical is the object; the mutation qualifier describes the gene.
-        if association_type == "GeneAffectsChemicalAssociation":
+        # For GeneAffectsChemicalAssociation and MacromolecularMachineHasSubstrateAssociation
+        # the gene/protein is the subject and the chemical is the object;
+        # the mutation qualifier describes the gene.
+        if association_type in ("GeneAffectsChemicalAssociation", "MacromolecularMachineHasSubstrateAssociation"):
             subject_id = target.id
             object_id = chemical.id
         else:
@@ -564,8 +565,8 @@ def get_association(koza, record, action_type_map):
                 predicate=predicate,
                 object=object_id,
                 species_context_qualifier = species_context_qualifier,
-                subject_form_or_variant_qualifier = mutation_qualifier if association_type == "GeneAffectsChemicalAssociation" else None,
-                object_form_or_variant_qualifier = mutation_qualifier if association_type != "GeneAffectsChemicalAssociation" else None,
+                subject_form_or_variant_qualifier = mutation_qualifier if association_type in ("GeneAffectsChemicalAssociation", "MacromolecularMachineHasSubstrateAssociation") else None,
+                object_form_or_variant_qualifier = mutation_qualifier if association_type not in ("GeneAffectsChemicalAssociation", "MacromolecularMachineHasSubstrateAssociation") else None,
                 sources=CHEMBL_SOURCES,
                 knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
                 agent_type=AgentTypeEnum.manual_agent,
@@ -599,7 +600,7 @@ def get_activity_association(koza: koza.KozaTransform, chemical, target, action_
         koza.log(f" Unknown association class for action type {record['action_type']}", level="WARNING")
         return None
 
-    if association_type == "GeneAffectsChemicalAssociation":
+    if association_type in ("GeneAffectsChemicalAssociation", "MacromolecularMachineHasSubstrateAssociation"):
         subject_id = target.id
         object_id = chemical.id
     else:

--- a/src/translator_ingest/ingests/chembl/chembl_qualifiers.json
+++ b/src/translator_ingest/ingests/chembl/chembl_qualifiers.json
@@ -50,7 +50,7 @@
         }
     },
     "BINDING AGENT": {
-        "association": "ChemicalAffectsGeneAssociation",
+        "association": "ChemicalGeneInteractionAssociation",
         "predicate": "biolink:directly_physically_interacts_with",
         "qualifiers": {
             "causal_mechanism_qualifier": "binding"
@@ -67,14 +67,14 @@
         }
     },
     "CHELATING AGENT": {
-        "association": "ChemicalAffectsGeneAssociation",
+        "association": "ChemicalGeneInteractionAssociation",
         "predicate": "biolink:directly_physically_interacts_with",
         "qualifiers": {
             "causal_mechanism_qualifier": "chelation"
         }
     },
     "CROSS-LINKING AGENT": {
-        "association": "ChemicalAffectsGeneAssociation",
+        "association": "ChemicalGeneInteractionAssociation",
         "predicate": "biolink:directly_physically_interacts_with",
         "qualifiers": {
             "causal_mechanism_qualifier": "crosslinking"
@@ -272,7 +272,7 @@
         }
     },
     "SEQUESTERING AGENT": {
-        "association": "ChemicalAffectsGeneAssociation",
+        "association": "ChemicalGeneInteractionAssociation",
         "predicate": "biolink:directly_physically_interacts_with",
         "qualifiers": {
             "causal_mechanism_qualifier": "sequestration"

--- a/src/translator_ingest/ingests/chembl/chembl_qualifiers.json
+++ b/src/translator_ingest/ingests/chembl/chembl_qualifiers.json
@@ -116,7 +116,7 @@
     },
     "HYDROLYTIC ENZYME": {
         "association": "GeneAffectsChemicalAssociation",
-        "predicate": "biolink:affected_by",
+        "predicate": "biolink:affects",
         "qualifiers": {
             "qualified_predicate": "biolink:causes",
             "object_aspect_qualifier": "hydrolysis",
@@ -192,7 +192,7 @@
         }
     },
     "OTHER": {
-        "association": "ChemicalAffectsGeneAssociation",
+        "association": "ChemicalGeneInteractionAssociation",
         "predicate": "biolink:interacts_with",
         "qualifiers": {}
     },
@@ -289,7 +289,7 @@
         }
     },
     "SUBSTRATE": {
-        "association": "GeneAffectsChemicalAssociation",
+        "association": "MacromolecularMachineHasSubstrateAssociation",
         "predicate": "biolink:has_substrate",
         "qualifiers": {}
     },

--- a/src/translator_ingest/ingests/chembl/chembl_qualifiers.json
+++ b/src/translator_ingest/ingests/chembl/chembl_qualifiers.json
@@ -187,8 +187,7 @@
             "qualified_predicate": "biolink:causes",
             "object_aspect_qualifier": "activity",
             "object_direction_qualifier": "increased",
-            "causal_mechanism_qualifier": "opening",
-            "TODO: causal_mechanism_qualifier": "molecular_channel_opening"
+            "causal_mechanism_qualifier": "opening"
         }
     },
     "OTHER": {

--- a/src/translator_ingest/ingests/chembl/chembl_rig.yaml
+++ b/src/translator_ingest/ingests/chembl/chembl_rig.yaml
@@ -182,12 +182,12 @@
 
       # MacromolecularMachineHasSubstrateAssociation: substrate relationships
       - subject_categories:
-          - ChemicalEntity
+          - Protein
+          - ProteinFamily
         predicates:
           - biolink:has_substrate
         object_categories:
-          - Protein
-          - ProteinFamily
+          - ChemicalEntity
         qualifiers:
           - property: "biolink:species_context_qualifier"
             value_id_prefixes:

--- a/src/translator_ingest/ingests/chembl/chembl_rig.yaml
+++ b/src/translator_ingest/ingests/chembl/chembl_rig.yaml
@@ -27,56 +27,50 @@
     scope: "Drugs and probes mechanisms, metabolism, bioactivity, gene targets"
 
     relevant_files:
-      - file_name: chembl_35_sqlite.tar.gz
+      - file_name: chembl_36_sqlite.tar.gz
         location: https://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/latest/
         description: "ChEMBL SQLite database"
 
-    included_content: 
-      - file_name: chembl_35_sqlite.tar.gz
+    included_content:
+      - file_name: chembl_36_sqlite.tar.gz
         included_records: "Drug mechanisms from the following tables: drug_mechanism, molecule_dictionary, target_dictionary, binding_sites, compound_records, docs, source, target_components, component_sequences, variant_sequences."
         fields_used: "drug_mechanism: mec_id, molregno, mechanism_of_action, action_type, direct_interaction, mechanism_comment, selectivity_comment, binding_site_comment, variant_id; molecule_dictionary: molregno, chembl_id; target_dictionary: tid, chembl_id (AS target_chembl_id), pref_name (AS target_name), target_type, organism (AS target_organism); binding_sites: site_id, site_name; compound_records: record_id, doc_id, src_id; docs: doc_id, chembl_id (AS document_chembl_id); source: src_id, src_description (AS source_description); target_components: tid, component_id; component_sequences: component_id, component_type, accession, description, tax_id, organism; variant_sequences: variant_id, mutation, accession (AS mutation_accession)"
-      - file_name: chembl_35_sqlite.tar.gz
-        included_records: "Gene targets - same as drug mechanisms with targets mapped to genets"
+      - file_name: chembl_36_sqlite.tar.gz
+        included_records: "Gene targets - same as drug mechanisms with targets mapped to genes"
         fields_used: "drug_mechanism: mec_id, molregno, mechanism_of_action, action_type, direct_interaction, mechanism_comment, selectivity_comment, binding_site_comment, variant_id; molecule_dictionary: molregno, chembl_id; target_dictionary: tid, chembl_id (AS target_chembl_id), pref_name (AS target_name), target_type, organism (AS target_organism); binding_sites: site_id, site_name; compound_records: record_id, doc_id, src_id; docs: doc_id, chembl_id (AS document_chembl_id); source: src_id, src_description (AS source_description); target_components: tid, component_id; component_sequences: component_id, component_type, accession, description, tax_id, organism; variant_sequences: variant_id, mutation, accession (AS mutation_accession)"
-      - file_name: chembl_35_sqlite.tar.gz
+      - file_name: chembl_36_sqlite.tar.gz
         included_records: "Metabolism information from the following tables: metabolism, molecule_dictionary, compound_records, compound_structures, target_dictionary, metabolism_refs"
         fields_used: "metabolism: drug_record_id, substrate_record_id, metabolite_record_id, met_id, enzyme_name, met_conversion, met_comment, organism, tax_id, enzyme_tid; molecule_dictionary: molregno, chembl_id, pref_name; compound_records: molregno, record_id, compound_name; target_dictionary: tid, target_type, chembl_id; compound_structures: molregno, standard_inchi, standard_inchi_key, canonical_smiles; metabolism_refs: met_id, ref_type, ref_id, ref_url"
-      - file_name: chembl_35_sqlite.tar.gz
+      - file_name: chembl_36_sqlite.tar.gz
         included_records: "Bioactivity and assay information from the following tables: activities, molecule_dictionary, assays, bioassay_ontology, target_dictionary, target_components, component_sequences, cell_dictionary, assay_type, tissue_dictionary, docs, source, ligand_eff, relationship_type, confidence_score_lookup, confidence_score_lookup"
         fields_used: "activities: activity_id, standard_type, standard_relation, standard_value, standard_units, pchembl_value, activity_comment, data_validity_comment, standard_text_value, standard_upper_value, uo_units, potential_duplicate, action_type, src_id, doc_id; molecule_dictionary: molregno, chembl_id; assays: assay_id, chembl_id, description, assay_organism, assay_cell_type, assay_subcellular_fraction, bao_format, assay_category, assay_tax_id, assay_tissue, relationship_type, confidence_score, curated_by, src_id, assay_type, cell_id, tissue_id, tid; bioassay_ontology: bao_id, label; target_dictionary: tid, chembl_id, pref_name, organism, target_type; target_components: tid, component_id; component_sequences: component_id, component_type, accession; cell_dictionary: cell_id, chembl_id, cell_name, cell_description, cell_source_tissue, cell_source_organism, cell_source_tax_id, clo_id, efo_id, cellosaurus_id, cl_lincs_id, cell_ontology_id; assay_type: assay_type, assay_desc; tissue_dictionary: tissue_id, chembl_id, pref_name; docs: doc_id, chembl_id, journal, title, year, authors, pubmed_id, doi; source: src_id, src_description; ligand_eff: activity_id, bei, le, lle, sei; relationship_type: relationship_type, relationship_desc; confidence_score_lookup: confidence_score, description, target_mapping; curation_lookup: curated_by, description"
 
     filtered_content:
-      - file_name: chembl_35_sqlite.tar.gz
+      - file_name: chembl_36_sqlite.tar.gz
         filtered_records: "Gene targets - removed targets that cannot be mapped to genes (like cell-lines)"
         rationale: "targets that cannot be mapped to genes"
 
-  target_info: 
+  target_info:
     infores_id: "infores:translator-chembl-kgx"
     edge_type_info:
 
-      # MHB:  Generally, the Edge Type descriptions don;t seem to be updated to refelct what data is actually in the KG - per the summary report here: https://docs.google.com/spreadsheets/d/1nt9s9NT_DloB6TMt_MpZDDvIVqtZeammLbxjPJvV6Xs/edit?.  gid=1712830697#gid=1712830697
-      # MHB: I made specific comments to this effect below - search for all "# MHB:" prefixed comments. 
+      # ChemicalAffectsGeneAssociation: chemical affects gene/protein target
       - subject_categories:
-          - SmallMolecule
-          - MolecularMixture
           - ChemicalEntity
-          - Protein
-        predicates:               # MHB: I don't see disrupts or regulates in the data . . . . can we remove the others, or should they be getting created?  I do however see a has_substrate predicate in the data (and the mappings file)- so this should be added here.
+        predicates:
           - biolink:affects
-          - biolink:disrupts
-          - biolink:regulates
-        object_categories:        # MHB: The only categories I see in the data are Protein, ChemicalEntity, and SmallMolecule - can we remove the others?
-          - CellLine
-          - CellularComponent
-          - CellularOrganism
-          - MacromolecularComplex
-          - MolecularActivity
-          - MolecularEntity
-          - NucleicAcidEntity
+        object_categories:
           - Protein
           - ProteinFamily
+          - MacromolecularComplex
+          - NucleicAcidEntity
+          - MolecularEntity
+          - MolecularActivity
           - SmallMolecule
-        qualifiers:              # I also see some edges with subject_aspect and subject_direction qualifiers in the data, and anatomical_context and causal_mechanism statement-level qualifiers - can we add this to the list of possible qualifiers for this edge type?
+          - CellularComponent
+          - CellularOrganism
+          - CellLine
+        qualifiers:
           - property: "biolink:qualified_predicate"
             value_enumeration:
               - "biolink:causes"
@@ -95,271 +89,215 @@
           - property: "biolink:object_form_or_variant_qualifier"
             value_range:
               - "biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum"
+          - property: "biolink:anatomical_context_qualifier"
+            value_id_prefixes:
+              - "UBERON"
         knowledge_level:
           - knowledge_assertion
         agent_type:
           - manual_agent
-          - automated_agent        
-        edge_properties:           # MHB: I don't see a lot of the edge properties below in the data according to the summary report.  They could be getting created by the code, but removed after NN/validation because perhaps they are not in biolink?  Fix for this is to add them to 'attirbutes.yaml' ... but we should be sure that NN / validators are looking in this file for acceptable properties.
+          - automated_agent
+        edge_properties:
           - biolink:publications
           - biolink:has_confidence_score
-          - mechanism_of_action_description
-          - mechanism_of_action_comment
-          - mutation
-          - mutation_accession
-          - selectivity_comment
-        ui_explanation: "Drug mechanisms, some mapped to genes, from ChEMBL"
-        additional_notes: "The 'mechanism' reported by Chembl determines that type of edge is created: (1) an 'affects'edge when the mechanism implies an effect of the subject on the object - e.g. 'stabilizer' implies that 'A causes increased stability of B'; a 'directly_physically_interacts_with' edge when the mechanism implies only that the subject interacts with B, but not an effect that results from this - e.g. 'cross-linking agent' implies only a physical interaction; (or (3) both 'affects' and 'directly_physically_interacts_with' edges, when the mechanism implies an effect that is necessarily mediated through a direct physical interaction - e.g. 'agonist' implies that 'A increases the activity of B' and that 'A directly physically interacts with B'. A full mapping of these chembl.mechanism to Biolink predicate and qualifier combinations can be found here: https://raw.githubusercontent.com/broadinstitute/molecular-data-provider/refs/heads/master/transformers/chembl/python-flask-server/conf/chembl_qualifiers.json."
+        ui_explanation: "Drug mechanisms and bioactivities where a chemical affects a gene or protein target"
+        additional_notes: "The 'mechanism' reported by ChEMBL determines the type of edge created. For mechanisms that imply an effect of the chemical on the target (e.g. 'agonist', 'inhibitor', 'stabiliser'), an 'affects' edge with appropriate qualifiers is created. A full mapping of ChEMBL mechanisms to Biolink predicate and qualifier combinations can be found in chembl_qualifiers.json."
 
-        # MHB: many of the same comments for this edge type as above, re: removing catogry values that don't show up in the data apply, 
+      # GeneAffectsChemicalAssociation: gene/protein target affects chemical
       - subject_categories:
-          - SmallMolecule
-          - MolecularMixture
-          - ChemicalEntity
           - Protein
-        predicates: 
-          - biolink:directly_physically_interacts_with
-        object_categories:
-          - CellLine
-          - CellularComponent
-          - CellularOrganism
           - MacromolecularComplex
-          - MolecularActivity
-          - MolecularEntity
           - NucleicAcidEntity
-          - Protein
-          - ProteinFamily
+          - MolecularEntity
           - SmallMolecule
-        qualifiers:                  # MHB: Again, I see anatomical_context and cuasal_mechanism statement-level qualifiers in the data - can we add this to the list of possible qualifiers for this edge type?
+        predicates:
+          - biolink:affects
+        object_categories:
+          - ChemicalEntity
+        qualifiers:
+          - property: "biolink:qualified_predicate"
+            value_enumeration:
+              - "biolink:causes"
+          - property: "biolink:object_direction_qualifier"
+            value_range:
+              - "biolink:DirectionQualifierEnum"
+          - property: "biolink:object_aspect_qualifier"
+            value_range:
+              - "biolink:GeneOrGeneProductOrChemicalEntityAspectEnum"
           - property: "biolink:species_context_qualifier"
             value_id_prefixes:
               - "NCBITaxon"
-          - property: "biolink:object_form_or_variant_qualifier"
+          - property: "biolink:subject_form_or_variant_qualifier"
             value_range:
               - "biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum"
         knowledge_level:
           - knowledge_assertion
         agent_type:
           - manual_agent
-        edge_properties:      # MHB: As above, most of these are not actually showing up in the final KG.. . .
+        edge_properties:
           - biolink:publications
           - biolink:has_confidence_score
-          - binding_site_name
-          - binding_site_comment
-          - mechanism_of_action_description
-          - mechanism_of_action_comment
-          - mutation
-          - mutation_accession
-          - selectivity_comment
-        ui_explanation: "Drug mechanisms, some mapped to genes, from ChEMBL"
-        additional_notes: "The 'mechanism' reported by Chembl determines that type of edge is created: (1) an 'affects' edge when the mechanism implies an effect of the subject on the object - e.g. 'stabilizer' implies that 'A causes increased stability of B'; a 'directly_physically_interacts_with' edge when the mechanism implies only that the subject interacts with B, but not an effect that results from this - e.g. 'cross-linking agent' implies only a physical interaction; (or (3) both 'affects' and 'directly_physically_interacts_with' edges, when the mechanism implies an effect that is necessarily mediated through a direct physical interaction - e.g. 'agonist' implies that 'A increases the activity of B' and that 'A directly physically interacts with B'. A full mapping of these chembl.mechanism to Biolink predicate and qualifier combinations can be found here: https://raw.githubusercontent.com/broadinstitute/molecular-data-provider/refs/heads/master/transformers/chembl/python-flask-server/conf/chembl_qualifiers.json."
+        ui_explanation: "Drug mechanisms where a gene or protein (e.g. enzyme) affects a chemical (e.g. hydrolysis, oxidation, reduction)"
+        additional_notes: "For mechanisms where the gene/protein acts on the chemical (e.g. 'hydrolytic enzyme', 'oxidative enzyme', 'reducing agent'), the gene is the subject and the chemical is the object. The object_aspect_qualifier and object_direction_qualifier describe what happens to the chemical."
 
+      # ChemicalGeneInteractionAssociation: direct physical interactions and untyped interactions
       - subject_categories:
-          - MacromolecularComplex
-        predicates: 
-          - biolink:has_part 
+          - ChemicalEntity
+        predicates:
+          - biolink:directly_physically_interacts_with
+          - biolink:interacts_with
         object_categories:
-          - NucleicAcidEntity
           - Protein
+          - ProteinFamily
+          - MacromolecularComplex
+          - NucleicAcidEntity
+          - MolecularEntity
+          - MolecularActivity
+          - SmallMolecule
+          - CellularComponent
+          - CellularOrganism
+          - CellLine
         qualifiers:
+          - property: "biolink:causal_mechanism_qualifier"
+            value_range:
+              - "biolink:CausalMechanismQualifierEnum"
           - property: "biolink:species_context_qualifier"
             value_id_prefixes:
               - "NCBITaxon"
-            value_description: "species tax id"
-        knowledge_level:
-          - knowledge_assertion
-        agent_type:
-          - manual_agent
-        edge_properties:
-        ui_explanation: "Component information from ChEMBL"
-
-      - subject_categories:
-          - SmallMolecule
-          - MolecularMixture
-          - ChemicalEntity
-        predicates: 
-          - biolink:has_metabolite
-        object_categories:
-          - SmallMolecule
-          - MolecularMixture
-          - ChemicalEntity
-        qualifiers:
-          - property: "biolink:species_context_qualifier"
+          - property: "biolink:object_form_or_variant_qualifier"
+            value_range:
+              - "biolink:ChemicalOrGeneOrGeneProductFormOrVariantEnum"
+          - property: "biolink:anatomical_context_qualifier"
             value_id_prefixes:
-              - "NCBITaxon"
-            value_description: "species tax id"
-          - property: "biolink:context_qualifier"
-            value_id_prefixes:
-              - "UniProtKB"
-            value_description: "enzyme identifier"
+              - "UBERON"
         knowledge_level:
           - knowledge_assertion
         agent_type:
           - manual_agent
         edge_properties:
           - biolink:publications
-          - metabolic conversion
-          - metabolic conversion comment
+          - biolink:has_confidence_score
+        ui_explanation: "Drug mechanisms where the mechanism implies a direct physical interaction (e.g. binding, chelation, crosslinking, sequestration)"
+        additional_notes: "For mechanisms that imply a physical interaction without a specified functional effect (e.g. 'binding agent', 'chelating agent', 'cross-linking agent'), a 'directly_physically_interacts_with' edge is created. Mechanisms classified as 'OTHER' produce an 'interacts_with' edge."
+
+      # MacromolecularMachineHasSubstrateAssociation: substrate relationships
+      - subject_categories:
+          - ChemicalEntity
+        predicates:
+          - biolink:has_substrate
+        object_categories:
+          - Protein
+          - ProteinFamily
+        qualifiers:
+          - property: "biolink:species_context_qualifier"
+            value_id_prefixes:
+              - "NCBITaxon"
+          - property: "biolink:anatomical_context_qualifier"
+            value_id_prefixes:
+              - "UBERON"
+        knowledge_level:
+          - knowledge_assertion
+        agent_type:
+          - manual_agent
+          - automated_agent
+        edge_properties:
+          - biolink:publications
+          - biolink:has_confidence_score
+        ui_explanation: "Substrate relationships from ChEMBL drug mechanisms and bioactivities"
+
+      # AnatomicalEntityHasPartAnatomicalEntityAssociation: complex/family composition
+      - subject_categories:
+          - MacromolecularComplex
+          - ProteinFamily
+          - MolecularActivity
+          - Protein
+        predicates:
+          - biolink:has_part
+        object_categories:
+          - Protein
+        knowledge_level:
+          - knowledge_assertion
+        agent_type:
+          - manual_agent
+        ui_explanation: "Component information from ChEMBL"
+
+      # ChemicalEntityToChemicalEntityAssociation: metabolism
+      - subject_categories:
+          - ChemicalEntity
+        predicates:
+          - biolink:has_metabolite
+        object_categories:
+          - ChemicalEntity
+        qualifiers:
+          - property: "biolink:species_context_qualifier"
+            value_id_prefixes:
+              - "NCBITaxon"
+            value_description: "species tax id"
+        knowledge_level:
+          - knowledge_assertion
+        agent_type:
+          - manual_agent
+        edge_properties:
+          - biolink:publications
         ui_explanation: "Metabolism information from ChEMBL"
 
     node_type_info:
 
-     # MHB: please remove any node types and node properties below that are not actually being created in the data. 
-      - node_category: AnatomicalEntity
-        source_identifier_types: 
-          - ChEMBL
-        node_properties:
-          - biolink:description
-          - biolink:in_taxon
-          - biolink:synonym
-          - biolink:xref
-
-      - node_category: BiologicalProcess
+      - node_category: CellLine
         source_identifier_types:
           - ChEMBL
-        node_properties:
-          - biolink:description
-          - biolink:in_taxon
-          - biolink:synonym
-          - biolink:xref
-
-      - node_category: Cell
-        source_identifier_types: 
-          - ChEMBL
-        node_properties:
-          - biolink:description
-          - biolink:in_taxon
-          - biolink:synonym
-          - biolink:xref
-
-      - node_category: CellLine
-        source_identifier_types: 
-          - ChEMBL
-        node_properties:
-          - biolink:description
-          - biolink:in_taxon
-          - biolink:synonym
-          - biolink:xref
 
       - node_category: CellularComponent
-        source_identifier_types: 
+        source_identifier_types:
           - ChEMBL
-        node_properties:
-          - biolink:description
-          - biolink:in_taxon
-          - biolink:synonym
-          - biolink:xref
 
       - node_category: CellularOrganism
         source_identifier_types:
           - ChEMBL
-        node_properties:
-          - biolink:description
-          - biolink:in_taxon
-          - biolink:synonym
-          - biolink:xref
 
       - node_category: ChemicalEntity
-        source_identifier_types: 
+        source_identifier_types:
           - ChEMBL
         node_properties:
-          - biolink:routes_of_delivery
           - biolink:synonym
           - biolink:xref
           - chembl_availability_type
           - chembl_black_box_warning
           - chembl_natural_product
           - chembl_prodrug
-
-      - node_category: Gene
-        source_identifier_types: 
-          - ChEMBL
-        node_properties:
-          - biolink:description
-          - biolink:in_taxon
-          - biolink:synonym
-          - biolink:xref
 
       - node_category: MacromolecularComplex
-        source_identifier_types: 
+        source_identifier_types:
           - ChEMBL
-        node_properties:
-          - biolink:description
-          - biolink:in_taxon
-          - biolink:synonym
-          - biolink:xref
 
       - node_category: MolecularActivity
-        source_identifier_types: 
+        source_identifier_types:
           - ChEMBL
-        node_properties:
-          - biolink:description
-          - biolink:in_taxon
-          - biolink:synonym
-          - biolink:xref
 
-      - node_category: MolecularMixture
-        source_identifier_types: 
+      - node_category: MolecularEntity
+        source_identifier_types:
           - ChEMBL
-        node_properties:
-          - biolink:routes_of_delivery
-          - biolink:synonym
-          - biolink:xref
-          - chembl_availability_type
-          - chembl_black_box_warning
-          - chembl_natural_product
-          - chembl_prodrug
-
 
       - node_category: NucleicAcidEntity
         source_identifier_types:
           - ChEMBL
-        node_properties:
-          - biolink:description
-          - biolink:in_taxon
-          - biolink:synonym
-          - biolink:xref
-
-      - node_category: PhenotypicFeature
-        source_identifier_types:
-          - ChEMBL
-        node_properties:
-          - biolink:description
-          - biolink:in_taxon
-          - biolink:synonym
-          - biolink:xref
 
       - node_category: Protein
         source_identifier_types:
           - ChEMBL
+          - UniProtKB
         node_properties:
-          - biolink:description
           - biolink:in_taxon
           - biolink:synonym
           - biolink:xref
 
       - node_category: ProteinFamily
-        source_identifier_types: 
+        source_identifier_types:
           - ChEMBL
-        node_properties:
-          - biolink:description
-          - biolink:in_taxon
-          - biolink:synonym
-          - biolink:xref
 
       - node_category: SmallMolecule
-        source_identifier_types: 
+        source_identifier_types:
           - ChEMBL
-        node_properties:
-          - biolink:routes_of_delivery
-          - biolink:synonym
-          - biolink:xref
-          - chembl_availability_type
-          - chembl_black_box_warning
-          - chembl_natural_product
-          - chembl_prodrug
-
-  # MHB: I don't see any future considerations in the RIG - I recally serveal things we talked about doing next iteration - esp w.r.t. bringing in data from the experimental activity tables, and additional EPC metadata and edge and node properties, etc.  
 
   provenance_info:
     contributions:

--- a/src/translator_ingest/ingests/gtopdb/gtopdb.py
+++ b/src/translator_ingest/ingests/gtopdb/gtopdb.py
@@ -978,34 +978,30 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
         if record["Type"] == "None" and record["Action"] not in none_list_with_separate_directly_physically_interacts_with_edge:
 
             if record["Action"] == "None":
-                predicate = BIOLINK_RELATED
-                object_aspect_qualifier = None
-                causal_mechanism_qualifier = None
-                object_direction_qualifier = None
-                qualified_predicate = None
+                association = Association(
+                    id=entity_id(),
+                    subject=subject.id,
+                    object=object.id,
+                    predicate=BIOLINK_RELATED,
+                    sources=GTOPDB_SOURCES,
+                    knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+                    agent_type=AgentTypeEnum.manual_agent,
+                )
             elif record["Action"] == "Potentiation":
-                predicate = current_predicate_mapping
-                object_aspect_qualifier = GeneOrGeneProductOrChemicalEntityAspectEnum.activity
-                qualified_predicate = BIOLINK_CAUSES
-                causal_mechanism_qualifier = CausalMechanismQualifierEnum.potentiation
-                object_direction_qualifier = current_direction_mapping[0]
+                association = ChemicalAffectsGeneAssociation(
+                    id=entity_id(),
+                    subject=subject.id,
+                    object=object.id,
+                    predicate=current_predicate_mapping,
+                    qualified_predicate=BIOLINK_CAUSES,
+                    object_aspect_qualifier=GeneOrGeneProductOrChemicalEntityAspectEnum.activity,
+                    object_direction_qualifier=current_direction_mapping[0],
+                    causal_mechanism_qualifier=CausalMechanismQualifierEnum.potentiation,
+                    sources=GTOPDB_SOURCES,
+                    knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+                    agent_type=AgentTypeEnum.manual_agent,
+                )
 
-            association = ChemicalAffectsGeneAssociation(
-                id=entity_id(),
-                subject=subject.id,
-                object=object.id,
-                ## Five edge attributes in order
-                predicate = predicate,
-                qualified_predicate = qualified_predicate,
-                object_aspect_qualifier = object_aspect_qualifier,
-                object_direction_qualifier = object_direction_qualifier,
-                causal_mechanism_qualifier = causal_mechanism_qualifier,
-                ## other edge attributes
-                sources=GTOPDB_SOURCES,
-                knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
-                agent_type=AgentTypeEnum.manual_agent,
-
-            )
             if publications:
                 association.publications = publications
 

--- a/src/translator_ingest/ingests/signor/signor.py
+++ b/src/translator_ingest/ingests/signor/signor.py
@@ -11,12 +11,12 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     ## necessary associations and interactions
     Association,
     GeneRegulatesGeneAssociation,
-    #PairwiseMolecularInteraction,
+    PairwiseGeneToGeneInteraction,
     GeneAffectsChemicalAssociation,
     ChemicalEntityToChemicalEntityAssociation,
     GeneOrGeneProductOrChemicalEntityAspectEnum,
     ChemicalAffectsGeneAssociation,
-    #PairwiseGeneToGeneInteraction,
+    ChemicalGeneInteractionAssociation,
     ## necessary enums
     CausalMechanismQualifierEnum,
     DirectionQualifierEnum,
@@ -337,7 +337,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     species_context_qualifier = species_context_qualifier,
                 )
 
-                association_2 = GeneRegulatesGeneAssociation(
+                association_2 = PairwiseGeneToGeneInteraction(
                     id=entity_id(),
                     subject=subject.id,
                     object=object.id,
@@ -348,8 +348,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     qualified_predicate = BIOLINK_CAUSES,
                     object_aspect_qualifier = object_aspect_qualifier,
                     object_direction_qualifier = object_direction_qualifier,
-                    ## QW: strange the GeneRegulatesGeneAssociation class doesn't support causal_mechanism_qualifier
-                    # causal_mechanism_qualifier = current_causal_mechanism_mapping,
+                    causal_mechanism_qualifier = current_causal_mechanism_mapping,
                     ## additional species and anatomical_context qualifiers if existing in the current association type
                     species_context_qualifier = species_context_qualifier,
                 )
@@ -463,7 +462,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     anatomical_context_qualifier = anatomical_context_qualifier,
                 )
 
-                association_2 = GeneAffectsChemicalAssociation(
+                association_2 = ChemicalGeneInteractionAssociation(
                     id=entity_id(),
                     subject=subject.id,
                     object=object.id,
@@ -474,8 +473,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     qualified_predicate = BIOLINK_CAUSES,
                     object_aspect_qualifier = object_aspect_qualifier,
                     object_direction_qualifier = object_direction_qualifier,
-                    ## QW: strange the GeneRegulatesGeneAssociation class doesn't support causal_mechanism_qualifier
-                    # causal_mechanism_qualifier = current_causal_mechanism_mapping,
+                    causal_mechanism_qualifier = current_causal_mechanism_mapping,
                     ## additional species and anatomical_context qualifiers if existing in the current association type
                     species_context_qualifier = species_context_qualifier,
                 )
@@ -555,7 +553,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     anatomical_context_qualifier = anatomical_context_qualifier,
                 )
 
-                association_2 = ChemicalAffectsGeneAssociation(
+                association_2 = ChemicalGeneInteractionAssociation(
                     id=entity_id(),
                     subject=subject.id,
                     object=object.id,
@@ -566,8 +564,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     qualified_predicate = BIOLINK_CAUSES,
                     object_aspect_qualifier = object_aspect_qualifier,
                     object_direction_qualifier = object_direction_qualifier,
-                    ## QW: strange the GeneRegulatesGeneAssociation class doesn't support causal_mechanism_qualifier
-                    # causal_mechanism_qualifier = current_causal_mechanism_mapping,
+                    causal_mechanism_qualifier = current_causal_mechanism_mapping,
                     ## additional species and anatomical_context qualifiers if existing in the current association type
                     species_context_qualifier = species_context_qualifier,
                 )

--- a/src/translator_ingest/ingests/signor/signor.py
+++ b/src/translator_ingest/ingests/signor/signor.py
@@ -546,7 +546,7 @@ def transform_ingest_all(koza: koza.KozaTransform, data: Iterable[dict[str, Any]
                     agent_type=AgentTypeEnum.manual_agent,
                     ## five edge attributes in order
                     predicate = current_predicate_mapping,
-                    qualified_predicate = BIOLINK_AFFECTS,
+                    qualified_predicate = BIOLINK_CAUSES,
                     object_aspect_qualifier = object_aspect_qualifier,
                     object_direction_qualifier = object_direction_qualifier,
                     causal_mechanism_qualifier = current_causal_mechanism_mapping,

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "biolink-model"
-version = "4.4.0rc3"
+version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -189,9 +189,9 @@ dependencies = [
     { name = "requests" },
     { name = "stringcase" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/01/19bbba4c34cdc6123fc475d5ab6e614e82572f79f88eaab8881bb9354cca/biolink_model-4.4.0rc3.tar.gz", hash = "sha256:42af338b432677c8b0d8ee03c00050678b538e00d341c6655df7a3c74c8d90a2", size = 3818297, upload-time = "2026-05-07T22:33:28.095Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/ae/0a8da43ad809d79f2d4da912a47b8901a8a069baa12910dcd0d3c06abdc5/biolink_model-4.4.0.tar.gz", hash = "sha256:08c703f3936a899ff3bc555c47dcda7ce6a3c81a88a89ee1f9fda7f2ea407fa9", size = 3817271, upload-time = "2026-05-07T23:55:38.755Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/48/e90c6449a745323a50068d841a9620af8c7fc53986f0b101d2cd22e1bff0/biolink_model-4.4.0rc3-py3-none-any.whl", hash = "sha256:6b81ee317ceb41bc4d8d9c060c2ed40ec2ed82fd5c173658d5530c358a3565ab", size = 334223, upload-time = "2026-05-07T22:33:26.658Z" },
+    { url = "https://files.pythonhosted.org/packages/74/5d/7b4a25c5fe7846d6a6e69129b6cfbc3d6928c8ea212bb7506bd79957135f/biolink_model-4.4.0-py3-none-any.whl", hash = "sha256:690ae5caaab2af8063dace85bd7418469f33c1d8b34f0274bcd8daac6178e4af", size = 334177, upload-time = "2026-05-07T23:55:37.199Z" },
 ]
 
 [[package]]
@@ -324,7 +324,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.2" },
-    { name = "biolink-model", specifier = "==4.4.0rc3" },
+    { name = "biolink-model", specifier = "==4.4.0" },
     { name = "bmt", specifier = ">=1.4.8" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "codespell", specifier = ">=2.4.1" },
@@ -346,7 +346,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "biolink-model", specifier = "==4.4.0rc3" },
+    { name = "biolink-model", specifier = "==4.4.0" },
     { name = "black", specifier = ">=24.1.0" },
     { name = "codespell", specifier = ">=2.2.0" },
     { name = "jsonlines" },
@@ -948,6 +948,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/c8/9d76a66421d1ae24340dfae7e79c313957f6e3195c144d2c73333b5bfe34/greenlet-3.3.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7e806ca53acf6d15a888405880766ec84721aa4181261cd11a457dfe9a7a4975", size = 276443, upload-time = "2026-01-23T15:30:10.066Z" },
     { url = "https://files.pythonhosted.org/packages/81/99/401ff34bb3c032d1f10477d199724f5e5f6fbfb59816ad1455c79c1eb8e7/greenlet-3.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d842c94b9155f1c9b3058036c24ffb8ff78b428414a19792b2380be9cecf4f36", size = 597359, upload-time = "2026-01-23T16:00:57.394Z" },
     { url = "https://files.pythonhosted.org/packages/2b/bc/4dcc0871ed557792d304f50be0f7487a14e017952ec689effe2180a6ff35/greenlet-3.3.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20fedaadd422fa02695f82093f9a98bad3dab5fcda793c658b945fcde2ab27ba", size = 607805, upload-time = "2026-01-23T16:05:28.068Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/7a7ca57588dac3389e97f7c9521cb6641fd8b6602faf1eaa4188384757df/greenlet-3.3.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c620051669fd04ac6b60ebc70478210119c56e2d5d5df848baec4312e260e4ca", size = 622363, upload-time = "2026-01-23T16:15:54.754Z" },
     { url = "https://files.pythonhosted.org/packages/cf/05/821587cf19e2ce1f2b24945d890b164401e5085f9d09cbd969b0c193cd20/greenlet-3.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14194f5f4305800ff329cbf02c5fcc88f01886cadd29941b807668a45f0d2336", size = 609947, upload-time = "2026-01-23T15:32:51.004Z" },
     { url = "https://files.pythonhosted.org/packages/a4/52/ee8c46ed9f8babaa93a19e577f26e3d28a519feac6350ed6f25f1afee7e9/greenlet-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7b2fe4150a0cf59f847a67db8c155ac36aed89080a6a639e9f16df5d6c6096f1", size = 1567487, upload-time = "2026-01-23T16:04:22.125Z" },
     { url = "https://files.pythonhosted.org/packages/8f/7c/456a74f07029597626f3a6db71b273a3632aecb9afafeeca452cfa633197/greenlet-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:49f4ad195d45f4a66a0eb9c1ba4832bb380570d361912fa3554746830d332149", size = 1636087, upload-time = "2026-01-23T15:33:47.486Z" },
@@ -956,6 +957,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/ab/d26750f2b7242c2b90ea2ad71de70cfcd73a948a49513188a0fc0d6fc15a/greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3", size = 275205, upload-time = "2026-01-23T15:30:24.556Z" },
     { url = "https://files.pythonhosted.org/packages/10/d3/be7d19e8fad7c5a78eeefb2d896a08cd4643e1e90c605c4be3b46264998f/greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac", size = 599284, upload-time = "2026-01-23T16:00:58.584Z" },
     { url = "https://files.pythonhosted.org/packages/ae/21/fe703aaa056fdb0f17e5afd4b5c80195bbdab701208918938bd15b00d39b/greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd", size = 610274, upload-time = "2026-01-23T16:05:29.312Z" },
+    { url = "https://files.pythonhosted.org/packages/06/00/95df0b6a935103c0452dad2203f5be8377e551b8466a29650c4c5a5af6cc/greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e", size = 624375, upload-time = "2026-01-23T16:15:55.915Z" },
     { url = "https://files.pythonhosted.org/packages/cb/86/5c6ab23bb3c28c21ed6bebad006515cfe08b04613eb105ca0041fecca852/greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3", size = 612904, upload-time = "2026-01-23T15:32:52.317Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f3/7949994264e22639e40718c2daf6f6df5169bf48fb038c008a489ec53a50/greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951", size = 1567316, upload-time = "2026-01-23T16:04:23.316Z" },
     { url = "https://files.pythonhosted.org/packages/8d/6e/d73c94d13b6465e9f7cd6231c68abde838bb22408596c05d9059830b7872/greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2", size = 1636549, upload-time = "2026-01-23T15:33:48.643Z" },

--- a/uv.lock
+++ b/uv.lock
@@ -175,8 +175,8 @@ wheels = [
 
 [[package]]
 name = "biolink-model"
-version = "4.4.1.post10.dev0+3d103756a"
-source = { git = "https://github.com/biolink/biolink-model.git?branch=chembl#3d103756ab139b3e7e877e6c82811773be67def4" }
+version = "4.4.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "click" },
@@ -188,6 +188,10 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "stringcase" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/51/c1911e3c34f53eefd6939083fbfba0ee02d070b6a261461f814f2ba644bd/biolink_model-4.4.2.tar.gz", hash = "sha256:c69ccb9fd8cbd9935b36a4aec578a4c5ee8a3c39d75eb4d9495ded6cf205c39b", size = 3784369, upload-time = "2026-05-22T19:09:21.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/63/545021b6c7162e2b6711d71f267cbab618598c1730e5de95a9d8c302adc1/biolink_model-4.4.2-py3-none-any.whl", hash = "sha256:939083a7f9c9ebe0fe580e6e02a9d01642825a85041be804e0e39a33fabc98d4", size = 336628, upload-time = "2026-05-22T19:09:18.783Z" },
 ]
 
 [[package]]
@@ -320,7 +324,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.2" },
-    { name = "biolink-model", git = "https://github.com/biolink/biolink-model.git?branch=chembl" },
+    { name = "biolink-model", specifier = "==4.4.2" },
     { name = "bmt", specifier = ">=1.4.8" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "codespell", specifier = ">=2.4.1" },
@@ -342,7 +346,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "biolink-model", git = "https://github.com/biolink/biolink-model.git?branch=chembl" },
+    { name = "biolink-model", specifier = "==4.4.2" },
     { name = "black", specifier = ">=24.1.0" },
     { name = "codespell", specifier = ">=2.2.0" },
     { name = "jsonlines" },

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "biolink-model"
-version = "4.4.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -189,9 +189,9 @@ dependencies = [
     { name = "requests" },
     { name = "stringcase" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/ae/0a8da43ad809d79f2d4da912a47b8901a8a069baa12910dcd0d3c06abdc5/biolink_model-4.4.0.tar.gz", hash = "sha256:08c703f3936a899ff3bc555c47dcda7ce6a3c81a88a89ee1f9fda7f2ea407fa9", size = 3817271, upload-time = "2026-05-07T23:55:38.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/a8/edb37099d23e353ac09d6e1c383fbaca6803364f15d5650e82e666a3402e/biolink_model-4.4.1.tar.gz", hash = "sha256:731753a5cfc6ceb82988c2c41dea39b80323cdf1e0028a9391711a2446bb6ebb", size = 3741171, upload-time = "2026-05-21T23:10:13.541Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/5d/7b4a25c5fe7846d6a6e69129b6cfbc3d6928c8ea212bb7506bd79957135f/biolink_model-4.4.0-py3-none-any.whl", hash = "sha256:690ae5caaab2af8063dace85bd7418469f33c1d8b34f0274bcd8daac6178e4af", size = 334177, upload-time = "2026-05-07T23:55:37.199Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ad/29b250a224595cba5ee4fc3f43b982a96a2aa95938aca60e2cd3f509fce4/biolink_model-4.4.1-py3-none-any.whl", hash = "sha256:3c2712e86faf9da70ca1525c465dd3c98abe7dc9846ee82b3d155a9ab05cd799", size = 334137, upload-time = "2026-05-21T23:10:11.525Z" },
 ]
 
 [[package]]
@@ -324,7 +324,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.2" },
-    { name = "biolink-model", specifier = "==4.4.0" },
+    { name = "biolink-model", specifier = "==4.4.1" },
     { name = "bmt", specifier = ">=1.4.8" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "codespell", specifier = ">=2.4.1" },
@@ -346,7 +346,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "biolink-model", specifier = "==4.4.0" },
+    { name = "biolink-model", specifier = "==4.4.1" },
     { name = "black", specifier = ">=24.1.0" },
     { name = "codespell", specifier = ">=2.2.0" },
     { name = "jsonlines" },

--- a/uv.lock
+++ b/uv.lock
@@ -175,8 +175,8 @@ wheels = [
 
 [[package]]
 name = "biolink-model"
-version = "4.4.1"
-source = { registry = "https://pypi.org/simple" }
+version = "4.4.1.post10.dev0+3d103756a"
+source = { git = "https://github.com/biolink/biolink-model.git?branch=chembl#3d103756ab139b3e7e877e6c82811773be67def4" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "click" },
@@ -188,10 +188,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "stringcase" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/a8/edb37099d23e353ac09d6e1c383fbaca6803364f15d5650e82e666a3402e/biolink_model-4.4.1.tar.gz", hash = "sha256:731753a5cfc6ceb82988c2c41dea39b80323cdf1e0028a9391711a2446bb6ebb", size = 3741171, upload-time = "2026-05-21T23:10:13.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/ad/29b250a224595cba5ee4fc3f43b982a96a2aa95938aca60e2cd3f509fce4/biolink_model-4.4.1-py3-none-any.whl", hash = "sha256:3c2712e86faf9da70ca1525c465dd3c98abe7dc9846ee82b3d155a9ab05cd799", size = 334137, upload-time = "2026-05-21T23:10:11.525Z" },
 ]
 
 [[package]]
@@ -324,7 +320,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.2" },
-    { name = "biolink-model", specifier = "==4.4.1" },
+    { name = "biolink-model", git = "https://github.com/biolink/biolink-model.git?branch=chembl" },
     { name = "bmt", specifier = ">=1.4.8" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "codespell", specifier = ">=2.4.1" },
@@ -346,7 +342,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "biolink-model", specifier = "==4.4.1" },
+    { name = "biolink-model", git = "https://github.com/biolink/biolink-model.git?branch=chembl" },
     { name = "black", specifier = ">=24.1.0" },
     { name = "codespell", specifier = ">=2.2.0" },
     { name = "jsonlines" },


### PR DESCRIPTION
- gtopdb, signor, chembl failed last ingest as a result of more strict pydantic validation in linkml upgrade we did.  unfortunately our test suite did not catch these errors (it did catch errors for a few other ingests that were fixed ahead of this PR when linkml was updated.  Look for another PR that does a comprehensive "test data" suite that exercises each edge declared in the rigs for passage so that if we upgrade biolink or linkml in this repo, we can test that upgrade ahead of PROD deployment with confidence).

- this also involved some small changes to biolink associations.  I did not change any existing edges in any of these three ingests (except flipping the direction of _some_ "affected_by" edges in chembl ingest to "affects" edges.  the subject/object qualfiiers were also swapped) so that we wouldn't have to worry that edges were changing without proper QA/QC.  

- The associations in biolink have the same edge properties/qualifiers available to them as the old associations in chembl did, just different predicate constraints (e.g. has_substrate).  This was also caught by Matt in the RIG for chembl, but not addressed yet.  Now with sticter validation, these changes had to go in.  The rig was also adjusted here. 

to test this, I:
- ran the test suite locally, all passed
- ran all the ingests in our repo locally because of the biolink-model changes.  All pass without error.  I did notice the new reporting for NodeNorm failures, and there are several ingests that need tickets put into babel to help; that will be a separate effort here. I like the new reporting!  