### PR TITLE
update default kgx storage urls

### DIFF
--- a/src/translator_ingest/__init__.py
+++ b/src/translator_ingest/__init__.py
@@ -18,5 +18,5 @@ INGESTS_PARSER_PATH = TRANSLATOR_INGEST_PATH / "ingests"
 INGEST_PARSER_DIR = INGESTS_PARSER_PATH.absolute()
 
 # Default public HTTPS endpoints for KGX storage (browser view format)
-INGESTS_STORAGE_URL = os.environ.get("INGESTS_STORAGE_URL", "https://kgx-storage.rtx.ai/data")
-INGESTS_RELEASES_URL = os.environ.get("INGESTS_RELEASES_URL", "https://kgx-storage.rtx.ai/releases")
+INGESTS_STORAGE_URL = os.environ.get("INGESTS_STORAGE_URL", "https://kgx-storage.ci.transltr.io/data")
+INGESTS_RELEASES_URL = os.environ.get("INGESTS_RELEASES_URL", "https://kgx-storage.ci.transltr.io/releases")


### PR DESCRIPTION
These URLs used for metadata outputs should've been overridden with env vars but it was overlooked in the transition to the new kgx storage location. This just changes the default so the main run doesn't need to override it.