### PR TITLE
Ubergraph predicates and refactor

### DIFF
--- a/src/translator_ingest/ingests/ubergraph/ubergraph.py
+++ b/src/translator_ingest/ingests/ubergraph/ubergraph.py
@@ -57,6 +57,12 @@ BIOLINK_MAPPING_CHANGES = {
     'NCBIGene': 'https://identifiers.org/ncbigene/'
 }
 
+# Source predicate IRIs mapped directly to their Biolink predicate. Only edges whose
+# predicate IRI appears here are ingested; add entries to support more predicates.
+PREDICATE_IRI_TO_BIOLINK = {
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": "biolink:subclass_of",
+}
+
 
 def get_latest_version() -> str:
     base_url = 'https://ubergraph.apps.renci.org'
@@ -141,7 +147,6 @@ def prepare_ontology_data(koza: koza.KozaTransform, data: Iterable[dict[str, Any
     node_curies = {}
     node_mapping_failures = []
     edge_curies = {}
-    edge_mapping_failures = []
 
     with tarfile.open(tar_path, 'r:gz') as tar:
         koza.log("Converting node IRIs to CURIEs...", level="INFO")
@@ -160,19 +165,14 @@ def prepare_ontology_data(koza: koza.KozaTransform, data: Iterable[dict[str, Any
         if node_mapping_failures:
             koza.log(f"Node conversion failure examples: {node_mapping_failures[:10]}", level="WARNING")
 
-        koza.log("Converting edge IRIs to CURIEs...", level="INFO")
+        koza.log("Mapping edge IRIs to Biolink predicates...", level="INFO")
         with tar.extractfile(f'{graph_base_path}/edge-labels.tsv') as edge_labels_file:
             for line in edge_labels_file:
                 edge_id, edge_iri = line.decode('utf-8').rstrip().split('\t')
-                edge_curie = curie_converter.compress(edge_iri)
-                if edge_iri == "http://www.w3.org/2000/01/rdf-schema#subClassOf":
-                    if edge_curie is not None:
-                        edge_curies[edge_id] = edge_curie
-                    else:
-                        edge_mapping_failures.append(edge_iri)
-        koza.log(f"Edges: {len(edge_curies):,} successfully converted, {len(edge_mapping_failures):,} failures.", level="INFO")
-        if edge_mapping_failures:
-            koza.log(f"Edge conversion failure examples: {edge_mapping_failures[:10]}", level="WARNING")
+                biolink_predicate = PREDICATE_IRI_TO_BIOLINK.get(edge_iri)
+                if biolink_predicate is not None:
+                    edge_curies[edge_id] = biolink_predicate
+        koza.log(f"Edges: {len(edge_curies):,} predicate IRIs mapped to Biolink predicates.", level="INFO")
 
         koza.state["node_curies"] = node_curies
         koza.state["edge_curies"] = edge_curies

--- a/src/translator_ingest/ingests/ubergraph/ubergraph.py
+++ b/src/translator_ingest/ingests/ubergraph/ubergraph.py
@@ -46,17 +46,6 @@ EXTRACTED_ONTOLOGY_PREFIXES = [
 
 EXTRACTED_ONTOLOGY_PREFIXES_SET = set(EXTRACTED_ONTOLOGY_PREFIXES)
 
-OBO_MISSING_MAPPINGS = {
-    'NCBIGene': 'http://purl.obolibrary.org/obo/NCBIGene_',
-    'HGNC': 'http://purl.obolibrary.org/obo/HGNC_',
-    'SGD': 'http://purl.obolibrary.org/obo/SGD_'
-}
-
-BIOLINK_MAPPING_CHANGES = {
-    'KEGG': 'http://identifiers.org/kegg/',
-    'NCBIGene': 'https://identifiers.org/ncbigene/'
-}
-
 # Source predicate IRIs mapped directly to their Biolink predicate. Only edges whose
 # predicate IRI appears here are ingested; add entries to support more predicates.
 PREDICATE_IRI_TO_BIOLINK = {
@@ -96,7 +85,6 @@ def get_biolink_prefix_map() -> dict:
             response.raise_for_status()
         biolink_prefix_map = response.json()
 
-    biolink_prefix_map.update(BIOLINK_MAPPING_CHANGES)
     return biolink_prefix_map
 
 
@@ -104,12 +92,10 @@ def init_curie_converter() -> curies.Converter:
     biolink_prefix_map = get_biolink_prefix_map()
     iri_to_biolink_curie_converter = curies.Converter.from_prefix_map(biolink_prefix_map)
     iri_to_obo_curie_converter = curies.get_obo_converter()
-    custom_converter = curies.Converter.from_prefix_map(OBO_MISSING_MAPPINGS)
 
     chain_converter = curies.chain([
         iri_to_biolink_curie_converter,
         iri_to_obo_curie_converter,
-        custom_converter,
     ])
     return chain_converter
 

--- a/src/translator_ingest/ingests/ubergraph/ubergraph.py
+++ b/src/translator_ingest/ingests/ubergraph/ubergraph.py
@@ -118,8 +118,6 @@ def init_curie_converter() -> curies.Converter:
 def on_begin_redundant_graph(koza: koza.KozaTransform) -> None:
     koza.state["record_counter"] = 0
     koza.state["skipped_record_counter"] = 0
-    koza.state["node_curies"] = {}
-    koza.state["edge_curies"] = {}
     koza.transform_metadata["redundant_graph"] = {
         "num_source_lines": 0,
         "unusable_source_lines": 0
@@ -174,28 +172,33 @@ def prepare_ontology_data(koza: koza.KozaTransform, data: Iterable[dict[str, Any
                     edge_curies[edge_id] = biolink_predicate
         koza.log(f"Edges: {len(edge_curies):,} predicate IRIs mapped to Biolink predicates.", level="INFO")
 
-        koza.state["node_curies"] = node_curies
-        koza.state["edge_curies"] = edge_curies
-
         koza.log("Streaming edges from tar archive...", level="INFO")
-        edge_stream_count = 0
+        source_line_count = 0
+        skipped_count = 0
         with tar.extractfile(f'{graph_base_path}/edges.tsv') as edges_file:
             for line in edges_file:
+                source_line_count += 1
                 subject_id, predicate_id, object_id = line.decode('utf-8').rstrip().split('\t')
-                # Only include edges where predicate is in our edge_curies dict (subClassOf only)
-                if predicate_id not in edge_curies:
+                # Only include edges where the predicate and nodes were mapped successfully,
+                # this excludes edges with predicates not in the PREDICATE_IRI_TO_BIOLINK lookup.
+                predicate = edge_curies.get(predicate_id)
+                subject_curie = node_curies.get(subject_id)
+                object_curie = node_curies.get(object_id)
+                if predicate is None or subject_curie is None or object_curie is None:
+                    skipped_count += 1
                     continue
-                # Only include edges where both subject and object are in our node_curies mapping
-                if subject_id not in node_curies or object_id not in node_curies:
-                    continue
-                
-                edge_stream_count += 1
                 yield {
-                    "subject_id": subject_id,
-                    "predicate_id": predicate_id,
-                    "object_id": object_id
+                    "subject": subject_curie,
+                    "predicate": predicate,
+                    "object": object_curie,
                 }
-        koza.log(f"Finished streaming {edge_stream_count:,} edges from tar archive.", level="INFO")
+        koza.state["record_counter"] = source_line_count
+        koza.state["skipped_record_counter"] = skipped_count
+        koza.log(
+            f"Finished streaming {source_line_count - skipped_count:,} edges "
+            f"from {source_line_count:,} source lines ({skipped_count:,} skipped).",
+            level="INFO",
+        )
 
 
 @koza.transform(tag="redundant_graph")
@@ -209,39 +212,22 @@ def transform_redundant_graph(koza: koza.KozaTransform, data: Iterable[dict[str,
     batch_count = 0
     
     for record in data:
-        koza.state["record_counter"] += 1
-        
-        subject_id = record["subject_id"]
-        predicate_id = record["predicate_id"]
-        object_id = record["object_id"]
-        
-        subject_curie = koza.state["node_curies"].get(subject_id)
-        if not subject_curie:
-            koza.state["skipped_record_counter"] += 1
-            continue
-        
-        object_curie = koza.state["node_curies"].get(object_id)
-        if not object_curie:
-            koza.state["skipped_record_counter"] += 1
-            continue
-        
-        predicate_curie = koza.state["edge_curies"].get(predicate_id)
-        if not predicate_curie:
-            koza.state["skipped_record_counter"] += 1
-            continue
-        
+        # Records are already filtered and converted to CURIEs/predicates in prepare_data.
+        subject_curie = record["subject"]
+        object_curie = record["object"]
+
         if subject_curie not in nodes_seen:
             nodes_batch.append(NamedThing(id=subject_curie))
             nodes_seen.add(subject_curie)
-        
+
         if object_curie not in nodes_seen:
             nodes_batch.append(NamedThing(id=object_curie))
             nodes_seen.add(object_curie)
-        
+
         edges_batch.append(Association(
             id=entity_id(),
             subject=subject_curie,
-            predicate=predicate_curie,
+            predicate=record["predicate"],
             object=object_curie,
             sources=UBERGRAPH_SOURCES,
             knowledge_level=KnowledgeLevelEnum.knowledge_assertion,

--- a/src/translator_ingest/ingests/ubergraph/ubergraph.py
+++ b/src/translator_ingest/ingests/ubergraph/ubergraph.py
@@ -27,7 +27,7 @@ EXTRACTED_ONTOLOGY_PREFIXES = [
     "CHEBI",
     "PR",
     "NCIT",
-    "HPO",
+    "HP",
     "MONDO",
     "RO",
     "SO",
@@ -38,7 +38,7 @@ EXTRACTED_ONTOLOGY_PREFIXES = [
     "OBI",
     "MAXO",
     "ECO",
-    "NCBITAXON",
+    "NCBITaxon",
     "FOODON",
     "MI",
     "UO"

--- a/src/translator_ingest/ingests/ubergraph/ubergraph_rig.yaml
+++ b/src/translator_ingest/ingests/ubergraph/ubergraph_rig.yaml
@@ -32,14 +32,14 @@ ingest_info:
 
   included_content:
     - file_name: "redundant-graph-table.tgz"
-      included_records: "Subclass (rdfs:subClassOf) edges where both subject and object are from selected biomedical ontologies"
+      included_records: "Subclass edges (source predicate rdfs:subClassOf, mapped to biolink:subclass_of) where both subject and object are from selected biomedical ontologies"
       fields_used: "subject_id, predicate_id, object_id (mapped via node-labels.tsv and edge-labels.tsv)"
-      ontology_prefixes_included: "UBERON, CL, GO, CHEBI, PR, NCIT, HPO, MONDO, RO, SO, MP, PATO, ECTO, ENVO, OBI, MAXO, ECO, NCBITAXON, FOODON, MI, UO"
+      ontology_prefixes_included: "UBERON, CL, GO, CHEBI, PR, NCIT, HP, MONDO, RO, SO, MP, PATO, ECTO, ENVO, OBI, MAXO, ECO, NCBITaxon, FOODON, MI, UO"
 
   filtered_content:
     - file_name: "redundant-graph-table.tgz"
       filtered_records: "Edges where subject, predicate, or object IRIs cannot be mapped to CURIEs"
-      rationale: "CURIE conversion is essential for integration with Translator infrastructure. IRIs that cannot be mapped lack appropriate prefix mappings in Biolink Model, OBO, or custom converters."
+      rationale: "CURIE conversion is essential for integration with Translator infrastructure. IRIs that cannot be mapped lack appropriate prefix mappings in the Biolink Model or OBO converters."
     - file_name: "redundant-graph-table.tgz"
       filtered_records: "All non-subClassOf predicates (e.g., part_of, has_part, regulates, etc.)"
       rationale: "Initial focus on hierarchical subclass relationships only. Other predicate types may be added in future iterations."
@@ -64,7 +64,7 @@ target_info:
     - subject_categories:
         - biolink:NamedThing
       predicates:
-        - rdfs:subClassOf
+        - biolink:subclass_of
       object_categories:
         - biolink:NamedThing
       knowledge_level:
@@ -84,7 +84,7 @@ target_info:
         - "CHEBI (chemical entities)"
         - "PR (proteins)"
         - "NCIT (NCI Thesaurus)"
-        - "HPO (human phenotype ontology)"
+        - "HP (human phenotype ontology)"
         - "MONDO (diseases)"
         - "RO (relation ontology - used as subjects/objects in some cases)"
         - "SO (sequence ontology)"
@@ -95,7 +95,7 @@ target_info:
         - "OBI (ontology for biomedical investigations)"
         - "MAXO (medical actions)"
         - "ECO (evidence codes)"
-        - "NCBITAXON (taxonomic classifications)"
+        - "NCBITaxon (taxonomic classifications)"
         - "FOODON (food ontology)"
         - "MI (molecular interactions)"
         - "UO (units of measurement)"

--- a/tests/unit/ingests/ubergraph/test_ubergraph.py
+++ b/tests/unit/ingests/ubergraph/test_ubergraph.py
@@ -19,8 +19,6 @@ from translator_ingest.ingests.ubergraph.ubergraph import (
     transform_redundant_graph,
     INFORES_UBERGRAPH,
     EXTRACTED_ONTOLOGY_PREFIXES,
-    OBO_MISSING_MAPPINGS,
-    BIOLINK_MAPPING_CHANGES,
 )
 
 SUBCLASS_OF_IRI = "http://www.w3.org/2000/01/rdf-schema#subClassOf"
@@ -33,17 +31,6 @@ def test_extracted_ontology_prefixes():
     assert "MONDO" in EXTRACTED_ONTOLOGY_PREFIXES
     assert "CHEBI" in EXTRACTED_ONTOLOGY_PREFIXES
     assert len(EXTRACTED_ONTOLOGY_PREFIXES) > 0
-
-
-def test_obo_missing_mappings():
-    assert OBO_MISSING_MAPPINGS["NCBIGene"] == "http://purl.obolibrary.org/obo/NCBIGene_"
-    assert OBO_MISSING_MAPPINGS["HGNC"] == "http://purl.obolibrary.org/obo/HGNC_"
-    assert OBO_MISSING_MAPPINGS["SGD"] == "http://purl.obolibrary.org/obo/SGD_"
-
-
-def test_biolink_mapping_changes():
-    assert BIOLINK_MAPPING_CHANGES["KEGG"] == "http://identifiers.org/kegg/"
-    assert BIOLINK_MAPPING_CHANGES["NCBIGene"] == "https://identifiers.org/ncbigene/"
 
 
 def test_infores_ubergraph():

--- a/tests/unit/ingests/ubergraph/test_ubergraph.py
+++ b/tests/unit/ingests/ubergraph/test_ubergraph.py
@@ -1,3 +1,6 @@
+import io
+import tarfile
+
 import pytest
 
 from biolink_model.datamodel.pydanticmodel_v2 import (
@@ -12,6 +15,7 @@ from tests.unit.ingests import MockKozaWriter, MockKozaTransform
 from translator_ingest.ingests.ubergraph.ubergraph import (
     on_begin_redundant_graph,
     on_end_redundant_graph,
+    prepare_ontology_data,
     transform_redundant_graph,
     INFORES_UBERGRAPH,
     EXTRACTED_ONTOLOGY_PREFIXES,
@@ -19,13 +23,15 @@ from translator_ingest.ingests.ubergraph.ubergraph import (
     BIOLINK_MAPPING_CHANGES,
 )
 
+SUBCLASS_OF_IRI = "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+PART_OF_IRI = "http://purl.obolibrary.org/obo/BFO_0000050"
+
 
 def test_extracted_ontology_prefixes():
     assert "UBERON" in EXTRACTED_ONTOLOGY_PREFIXES
     assert "GO" in EXTRACTED_ONTOLOGY_PREFIXES
     assert "MONDO" in EXTRACTED_ONTOLOGY_PREFIXES
     assert "CHEBI" in EXTRACTED_ONTOLOGY_PREFIXES
-    assert "HPO" in EXTRACTED_ONTOLOGY_PREFIXES
     assert len(EXTRACTED_ONTOLOGY_PREFIXES) > 0
 
 
@@ -66,8 +72,6 @@ def test_on_begin_redundant_graph():
 
     assert mock_koza.state["record_counter"] == 0
     assert mock_koza.state["skipped_record_counter"] == 0
-    assert mock_koza.state["node_curies"] == {}
-    assert mock_koza.state["edge_curies"] == {}
     assert mock_koza.transform_metadata["redundant_graph"]["num_source_lines"] == 0
     assert mock_koza.transform_metadata["redundant_graph"]["unusable_source_lines"] == 0
 
@@ -86,31 +90,74 @@ def test_on_end_redundant_graph():
     assert mock_koza.transform_metadata["redundant_graph"]["unusable_source_lines"] == 10
 
 
-@pytest.fixture
-def mock_koza_with_state():
-    writer = MockKozaWriter()
-    mock_koza = MockKozaTransform(extra_fields={}, writer=writer, mappings={})
-    mock_koza.state = {
-        "record_counter": 0,
-        "skipped_record_counter": 0,
-        "node_curies": {
-            "n1": "GO:0008150",
-            "n2": "UBERON:0001062",
-            "n3": "MONDO:0000001",
-        },
-        "edge_curies": {
-            "e1": "rdfs:subClassOf",
-        }
+def _write_redundant_graph_tgz(directory, node_labels, edge_labels, edges):
+    """Build a redundant-graph-table.tgz fixture matching the Ubergraph layout.
+
+    Each argument is a list of tab-separated-value rows (without trailing newlines).
+    """
+    tar_path = directory / "redundant-graph-table.tgz"
+    members = {
+        "redundant-graph-table/node-labels.tsv": node_labels,
+        "redundant-graph-table/edge-labels.tsv": edge_labels,
+        "redundant-graph-table/edges.tsv": edges,
     }
-    return mock_koza
+    with tarfile.open(tar_path, "w:gz") as tar:
+        for name, rows in members.items():
+            payload = ("\n".join(rows) + "\n").encode("utf-8")
+            info = tarfile.TarInfo(name=name)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+    return tar_path
 
 
-def test_transform_creates_nodes_and_edges(mock_koza_with_state):
+def test_prepare_ontology_data_filters_and_converts(tmp_path):
+    # Node ids: GO/UBERON/HP are retained ontologies; "unmapped" has no CURIE;
+    # BFO maps to a CURIE but is not in the extraction allow-list.
+    node_labels = [
+        "1\thttp://purl.obolibrary.org/obo/GO_0008150",
+        "2\thttp://purl.obolibrary.org/obo/UBERON_0001062",
+        "3\thttp://purl.obolibrary.org/obo/HP_0000118",
+        "4\thttp://example.org/unmapped_thing",
+        "5\thttp://purl.obolibrary.org/obo/BFO_0000001",
+    ]
+    edge_labels = [
+        f"10\t{SUBCLASS_OF_IRI}",
+        f"11\t{PART_OF_IRI}",
+    ]
+    edges = [
+        "1\t10\t2",  # GO subClassOf UBERON -> kept
+        "3\t10\t2",  # HP subClassOf UBERON -> kept (verifies the HP prefix fix)
+        "1\t11\t2",  # GO part_of UBERON   -> skipped (predicate not mapped)
+        "1\t10\t4",  # GO subClassOf unmapped -> skipped (object has no CURIE)
+        "1\t10\t5",  # GO subClassOf BFO   -> skipped (object not in allow-list)
+    ]
+    _write_redundant_graph_tgz(tmp_path, node_labels, edge_labels, edges)
+
+    mock_koza = MockKozaTransform(
+        extra_fields={}, writer=MockKozaWriter(), mappings={}, input_files_dir=tmp_path
+    )
+
+    records = list(prepare_ontology_data(mock_koza, iter([])))
+
+    assert records == [
+        {"subject": "GO:0008150", "predicate": "biolink:subclass_of", "object": "UBERON:0001062"},
+        {"subject": "HP:0000118", "predicate": "biolink:subclass_of", "object": "UBERON:0001062"},
+    ]
+    assert mock_koza.state["record_counter"] == 5
+    assert mock_koza.state["skipped_record_counter"] == 3
+
+
+@pytest.fixture
+def mock_koza():
+    return MockKozaTransform(extra_fields={}, writer=MockKozaWriter(), mappings={})
+
+
+def test_transform_creates_nodes_and_edges(mock_koza):
     data = [
-        {"subject_id": "n1", "predicate_id": "e1", "object_id": "n2"},
+        {"subject": "GO:0008150", "predicate": "biolink:subclass_of", "object": "UBERON:0001062"},
     ]
 
-    results = list(transform_redundant_graph(mock_koza_with_state, iter(data)))
+    results = list(transform_redundant_graph(mock_koza, iter(data)))
 
     assert len(results) == 1
     kg = results[0]
@@ -128,42 +175,20 @@ def test_transform_creates_nodes_and_edges(mock_koza_with_state):
     assert isinstance(edge, Association)
     assert edge.subject == "GO:0008150"
     assert edge.object == "UBERON:0001062"
-    assert edge.predicate == "rdfs:subClassOf"
+    assert edge.predicate == "biolink:subclass_of"
     assert edge.knowledge_level == KnowledgeLevelEnum.knowledge_assertion
     assert edge.agent_type == AgentTypeEnum.manual_agent
     assert len(edge.sources) == 1
     assert edge.sources[0].resource_id == INFORES_UBERGRAPH
 
 
-def test_transform_skips_missing_node_curies(mock_koza_with_state):
+def test_transform_deduplicates_nodes(mock_koza):
     data = [
-        {"subject_id": "n99", "predicate_id": "e1", "object_id": "n2"},
+        {"subject": "GO:0008150", "predicate": "biolink:subclass_of", "object": "UBERON:0001062"},
+        {"subject": "GO:0008150", "predicate": "biolink:subclass_of", "object": "MONDO:0000001"},
     ]
 
-    results = list(transform_redundant_graph(mock_koza_with_state, iter(data)))
-
-    assert len(results) == 0
-    assert mock_koza_with_state.state["skipped_record_counter"] == 1
-
-
-def test_transform_skips_missing_edge_curies(mock_koza_with_state):
-    data = [
-        {"subject_id": "n1", "predicate_id": "e99", "object_id": "n2"},
-    ]
-
-    results = list(transform_redundant_graph(mock_koza_with_state, iter(data)))
-
-    assert len(results) == 0
-    assert mock_koza_with_state.state["skipped_record_counter"] == 1
-
-
-def test_transform_deduplicates_nodes(mock_koza_with_state):
-    data = [
-        {"subject_id": "n1", "predicate_id": "e1", "object_id": "n2"},
-        {"subject_id": "n1", "predicate_id": "e1", "object_id": "n3"},
-    ]
-
-    results = list(transform_redundant_graph(mock_koza_with_state, iter(data)))
+    results = list(transform_redundant_graph(mock_koza, iter(data)))
 
     assert len(results) == 1
     kg = results[0]


### PR DESCRIPTION
Ubergraph ingest: predicate mapping, prefix fix, and cleanup

**Emit biolink:subclass_of instead of rdfs:subClassOf.** Added a PREDICATE_IRI_TO_BIOLINK map so source predicate IRIs are converted directly to Biolink predicates. Replaced the per-edge curies.compress() call and the subClassOf special-case with a single dict lookup.

**Fixed prefix filter dropping all HP and NCBITaxon nodes.** The extraction allow-list used HPO and NCBITAXON, but the converter emits the canonical prefixes HP and NCBITaxon, so those nodes — and every subclass edge touching them — were silently filtered out. Corrected the allow-list entries. Verified HP: and NCBITaxon: CURIEs normalize correctly downstream in NodeNorm.

**Removed duplicated filtering between prepare_data and transform.** prepare_data now converts IRIs to CURIEs/predicates once and yields ready-to-use records; transform builds nodes/edges directly. This removes never-firing skip branches and stops including large CURIE maps in koza.state. Source/skipped line counts are now tracked accurately.

**Removed dead custom mappings.** Deleted OBO_MISSING_MAPPINGS and BIOLINK_MAPPING_CHANGES (and their use in the converter chain); their prefixes were never in the extraction allow-list, so they had no effect on output.

**Updated tests and the RIG.** Reworked unit tests to the new record shape, added a prepare_data test (with a tar fixture) covering filtering and the HP fix end-to-end, and updated ubergraph_rig.yaml to reflect the biolink:subclass_of predicate and HP/NCBITaxon prefixes.