### PR TITLE
Semantic Versioning

### DIFF
--- a/src/translator_ingest/merging.py
+++ b/src/translator_ingest/merging.py
@@ -8,7 +8,7 @@ from orion import KGXFileMerger, KGXGraphMetadata, KGXKnowledgeSource, generate_
 
 from translator_ingest import INGESTS_DATA_PATH, INGESTS_RELEASES_PATH, INGESTS_RELEASES_URL
 from translator_ingest.release import create_compressed_tar, atomic_copy_directory
-from translator_ingest.util.metadata import PipelineMetadata, get_kgx_source_from_rig
+from translator_ingest.util.metadata import PipelineMetadata, get_kgx_source_from_rig, next_release_version
 from translator_ingest.util.storage.local import get_versioned_file_paths, IngestFileType, IngestFileName, \
     write_ingest_file
 from translator_ingest.util.logging_utils import get_logger, setup_logging
@@ -240,9 +240,18 @@ def merge(graph_id: str, sources: list[str], overwrite: bool = False) -> tuple[P
     biolink_version = list(biolink_versions)[0]
     babel_version = list(babel_versions)[0]
 
+    # Read the previous release version (if any) to determine the next semantic version
+    previous_release_metadata_path = get_versioned_file_paths(
+        IngestFileType.LATEST_RELEASE_FILE, PipelineMetadata(source=graph_id)
+    )
+    previous_release_version = None
+    if previous_release_metadata_path.exists():
+        with previous_release_metadata_path.open("r") as previous_release_file:
+            previous_release_version = PipelineMetadata.from_dict(json.load(previous_release_file)).release_version
+
     # Generate a build version based on the build versions of all source graphs
     build_version = hashlib.md5("".join(sorted(graph_source_versions)).encode()).hexdigest()[:12]
-    release_version = datetime.datetime.now().strftime("%Y_%m_%d")
+    release_version = next_release_version(previous_release_version)
     data_path = f"{INGESTS_RELEASES_URL}/{graph_id}/{release_version}/"
 
     # TODO - this should probably use a different kind of Metadata object, PipelineMetadata is designed for one ingest

--- a/src/translator_ingest/merging.py
+++ b/src/translator_ingest/merging.py
@@ -8,7 +8,8 @@ from orion import KGXFileMerger, KGXGraphMetadata, KGXKnowledgeSource, generate_
 
 from translator_ingest import INGESTS_DATA_PATH, INGESTS_RELEASES_PATH, INGESTS_RELEASES_URL
 from translator_ingest.release import create_compressed_tar, atomic_copy_directory
-from translator_ingest.util.metadata import PipelineMetadata, get_kgx_source_from_rig, next_release_version
+from translator_ingest.util.metadata import PipelineMetadata, get_kgx_source_from_rig, next_release_version, \
+    current_iso_date
 from translator_ingest.util.storage.local import get_versioned_file_paths, IngestFileType, IngestFileName, \
     write_ingest_file
 from translator_ingest.util.logging_utils import get_logger, setup_logging
@@ -156,7 +157,8 @@ def generate_merged_graph_release(merged_graph_metadata: PipelineMetadata):
     latest_dir = Path(INGESTS_RELEASES_PATH) / merged_graph_metadata.source / "latest"
     atomic_copy_directory(release_dir, latest_dir)
 
-    # Write latest release metadata
+    # Write latest release metadata, stamping the date the release was made
+    merged_graph_metadata.release_date = current_iso_date()
     release_dir = Path(INGESTS_RELEASES_PATH) / merged_graph_metadata.source
     release_dir.mkdir(parents=True, exist_ok=True)
     write_ingest_file(IngestFileType.LATEST_RELEASE_FILE,
@@ -262,6 +264,7 @@ def merge(graph_id: str, sources: list[str], overwrite: bool = False) -> tuple[P
         babel_version=babel_version,
         biolink_version=biolink_version,
         build_version=build_version,
+        build_date=current_iso_date(),
         release_version=release_version,
         data=data_path,
     )

--- a/src/translator_ingest/pipeline.py
+++ b/src/translator_ingest/pipeline.py
@@ -24,7 +24,7 @@ from orion.normalization import get_current_node_norm_version, get_current_babel
 from translator_ingest import INGESTS_PARSER_PATH, INGESTS_STORAGE_URL
 from translator_ingest.merging import merge_single
 from translator_ingest.normalize import normalize_kgx_files
-from translator_ingest.util.metadata import PipelineMetadata, get_kgx_source_from_rig
+from translator_ingest.util.metadata import PipelineMetadata, get_kgx_source_from_rig, current_iso_date
 from translator_ingest.util.storage.local import (
     get_output_directory,
     get_source_data_directory,
@@ -672,6 +672,7 @@ def run_pipeline(source: str, transform_only: bool = False, overwrite: bool = Fa
         return
 
     pipeline_metadata.build_version = pipeline_metadata.generate_build_version()
+    pipeline_metadata.build_date = current_iso_date()
     if is_graph_metadata_complete(pipeline_metadata) and not overwrite:
         logger.info(
             f"Graph metadata already completed for {pipeline_metadata.source} ({pipeline_metadata.source_version})."

--- a/src/translator_ingest/release.py
+++ b/src/translator_ingest/release.py
@@ -6,7 +6,7 @@ import zstandard as zstd
 from pathlib import Path
 
 from translator_ingest import INGESTS_RELEASES_PATH, INGESTS_RELEASES_URL
-from translator_ingest.util.metadata import PipelineMetadata, next_release_version
+from translator_ingest.util.metadata import PipelineMetadata, next_release_version, current_iso_date
 from translator_ingest.util.storage.local import get_versioned_file_paths, IngestFileType, write_ingest_file
 from translator_ingest.util.logging_utils import get_logger, setup_logging
 
@@ -143,9 +143,10 @@ def release_ingest(source: str):
     atomic_copy_directory(release_dir, latest_dir)
     logger.info("Copied release to latest directory")
 
-    # Write the new latest-release-metadata
+    # Write the new latest-release-metadata, stamping the date the release was made
     latest_release_metadata = latest_build_metadata
     latest_release_metadata.release_version = release_version
+    latest_release_metadata.release_date = current_iso_date()
     latest_release_metadata.data = release_url
 
     write_ingest_file(IngestFileType.LATEST_RELEASE_FILE,

--- a/src/translator_ingest/release.py
+++ b/src/translator_ingest/release.py
@@ -2,12 +2,11 @@ import json
 import shutil
 import tarfile
 import click
-import datetime
 import zstandard as zstd
 from pathlib import Path
 
 from translator_ingest import INGESTS_RELEASES_PATH, INGESTS_RELEASES_URL
-from translator_ingest.util.metadata import PipelineMetadata
+from translator_ingest.util.metadata import PipelineMetadata, next_release_version
 from translator_ingest.util.storage.local import get_versioned_file_paths, IngestFileType, write_ingest_file
 from translator_ingest.util.logging_utils import get_logger, setup_logging
 
@@ -111,10 +110,12 @@ def release_ingest(source: str):
         file_type=IngestFileType.LATEST_RELEASE_FILE,
         pipeline_metadata=PipelineMetadata(source=source)
     )
+    previous_release_version = None
     if latest_release_metadata_file_path.exists():
         with open(latest_release_metadata_file_path, 'r') as f:
             latest_release_metadata = PipelineMetadata.from_dict(json.load(f))
             latest_released_build = latest_release_metadata.build_version
+            previous_release_version = latest_release_metadata.release_version
             # if the latest release is already of the latest build, no need to do anything
             if latest_released_build == latest_build:
                 logger.info(f"Release already current for {source}.")
@@ -125,8 +126,8 @@ def release_ingest(source: str):
     graph_metadata_path = get_versioned_file_paths(IngestFileType.GRAPH_METADATA_FILE, latest_build_metadata)
     test_data_path = get_versioned_file_paths(IngestFileType.TEST_DATA_FILE, latest_build_metadata)
 
-    # Create the release
-    release_version = datetime.datetime.now().strftime("%Y_%m_%d")
+    # Create the release, bumping the version from the previous release
+    release_version = next_release_version(previous_release_version)
     release_dir = Path(INGESTS_RELEASES_PATH) / source / release_version
     release_url = f"{INGESTS_RELEASES_URL}/{source}/{release_version}/"
     create_release(source,

--- a/src/translator_ingest/util/metadata.py
+++ b/src/translator_ingest/util/metadata.py
@@ -1,6 +1,6 @@
 import re
-import datetime
 import yaml
+from datetime import datetime, timezone
 from dataclasses import dataclass, field, fields, asdict
 from typing import Any, Dict
 
@@ -88,8 +88,8 @@ class PipelineMetadata:
         return pipeline_metadata_dict
 
 def current_iso_date() -> str:
-    """Return today's date as an ISO 8601 string (YYYY-MM-DD)."""
-    return datetime.date.today().isoformat()
+    # Current UTC timestamp in ISO 8601 format (e.g., "2026-07-09T14:23:51Z"), with seconds precision.
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def next_release_version(previous_release_version: str | None) -> str:

--- a/src/translator_ingest/util/metadata.py
+++ b/src/translator_ingest/util/metadata.py
@@ -1,3 +1,4 @@
+import re
 import yaml
 from dataclasses import dataclass, field, fields, asdict
 from typing import Any, Dict
@@ -5,6 +6,9 @@ from typing import Any, Dict
 from orion import KGXKnowledgeSource
 
 from translator_ingest import INGESTS_PARSER_PATH
+
+# Matches a semantic version of the form MAJOR.MINOR.PATCH (e.g. "1.0.0").
+SEMANTIC_VERSION_PATTERN = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 
 
 @dataclass
@@ -77,6 +81,32 @@ class PipelineMetadata:
         pipeline_metadata_dict = asdict(self)
         del pipeline_metadata_dict["koza_config"]
         return pipeline_metadata_dict
+
+def next_release_version(previous_release_version: str | None) -> str:
+    """Compute the next semantic release version (MAJOR.MINOR.PATCH).
+
+    The patch component is bumped on every release. If there is no previous
+    release carrying a valid semantic version (``None``, or a legacy
+    date-based version like ``"2026_06_10"``), versioning starts fresh at
+    ``"1.0.0"``.
+
+    >>> next_release_version(None)
+    '1.0.0'
+    >>> next_release_version("2026_06_10")
+    '1.0.0'
+    >>> next_release_version("1.0.0")
+    '1.0.1'
+    >>> next_release_version("1.2.9")
+    '1.2.10'
+    """
+    if previous_release_version is None:
+        return "1.0.0"
+    match = SEMANTIC_VERSION_PATTERN.match(previous_release_version)
+    if not match:
+        return "1.0.0"
+    major, minor, patch = (int(part) for part in match.groups())
+    return f"{major}.{minor}.{patch + 1}"
+
 
 def get_kgx_source_from_rig(source: str) -> KGXKnowledgeSource:
     """Read a source's rig YAML file and create a KGXSource instance."""

--- a/src/translator_ingest/util/metadata.py
+++ b/src/translator_ingest/util/metadata.py
@@ -1,4 +1,5 @@
 import re
+import datetime
 import yaml
 from dataclasses import dataclass, field, fields, asdict
 from typing import Any, Dict
@@ -39,9 +40,13 @@ class PipelineMetadata:
     # build_version: a composite version representing all the dependencies which should be considered when determining
     # whether the pipeline needs to be run, or if an ingest was already fully completed
     build_version: str | None = None
+    # build_date: the date (ISO 8601, YYYY-MM-DD) the build was generated
+    build_date: str | None = None
     # release_version: a version assigned to a completed ingest when it is released
     # (moved to the releases directory, compressed, and distribution metadata generated)
     release_version: str | None = None
+    # release_date: the date (ISO 8601, YYYY-MM-DD) the release was made
+    release_date: str | None = None
     # data: a URL pointing to the pipeline stage artifacts used to process an entire ingest
     data: str | None = None
     # koza_config: the koza config yaml file associated with an ingest
@@ -81,6 +86,11 @@ class PipelineMetadata:
         pipeline_metadata_dict = asdict(self)
         del pipeline_metadata_dict["koza_config"]
         return pipeline_metadata_dict
+
+def current_iso_date() -> str:
+    """Return today's date as an ISO 8601 string (YYYY-MM-DD)."""
+    return datetime.date.today().isoformat()
+
 
 def next_release_version(previous_release_version: str | None) -> str:
     """Compute the next semantic release version (MAJOR.MINOR.PATCH).

--- a/tests/unit/test_release.py
+++ b/tests/unit/test_release.py
@@ -1,4 +1,5 @@
 """Tests for the release write path (release_ingest)."""
+import datetime
 import json
 
 import pytest
@@ -6,7 +7,7 @@ import pytest
 import translator_ingest.release
 import translator_ingest.util.storage.local as local_storage
 from translator_ingest.release import release_ingest
-from translator_ingest.util.metadata import PipelineMetadata, current_iso_date
+from translator_ingest.util.metadata import PipelineMetadata
 
 # Version fields used to build the on-disk directory tree. The merge directory path is derived
 # from these individual fields (not from build_version), so changing only build_version between
@@ -83,9 +84,12 @@ def test_release_ingest_first_release(release_env):
     release_metadata = _read_latest_release(releases_path)
     assert release_metadata["release_version"] == "1.0.0"
     assert release_metadata["build_version"] == "build1"
-    # build_date is preserved from the build; release_date is stamped now.
+    # build_date is preserved from the build; release_date is stamped now as a
+    # timezone-aware UTC ISO 8601 timestamp (e.g. "2026-07-09T14:23:51Z").
     assert release_metadata["build_date"] == "2026-01-01"
-    assert release_metadata["release_date"] == current_iso_date()
+    release_date = datetime.datetime.fromisoformat(release_metadata["release_date"])
+    assert release_date.tzinfo is not None
+    assert release_date.date() == datetime.datetime.now(datetime.timezone.utc).date()
 
     # The versioned release directory and its compressed archive exist, and are copied to latest.
     assert (releases_path / SOURCE / "1.0.0" / f"{SOURCE}.tar.zst").exists()

--- a/tests/unit/test_release.py
+++ b/tests/unit/test_release.py
@@ -1,0 +1,122 @@
+"""Tests for the release write path (release_ingest)."""
+import json
+
+import pytest
+
+import translator_ingest.release
+import translator_ingest.util.storage.local as local_storage
+from translator_ingest.release import release_ingest
+from translator_ingest.util.metadata import PipelineMetadata, current_iso_date
+
+# Version fields used to build the on-disk directory tree. The merge directory path is derived
+# from these individual fields (not from build_version), so changing only build_version between
+# releases reuses the same source files while producing a new release.
+SOURCE = "testsrc"
+BASE_METADATA = dict(
+    source=SOURCE,
+    source_version="v1",
+    transform_version="tv1",
+    babel_version="b1",
+    node_normalizer_version="nn1",
+    normalization_code_version="nc1",
+    normalization_conflation=True,
+    normalization_strict=True,
+    merging_code_version="mc1",
+    biolink_version="bl1",
+)
+
+
+def _write_json(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        json.dump(payload, f, indent=2)
+
+
+@pytest.fixture
+def release_env(tmp_path, monkeypatch):
+    """Build a minimal data/ and releases/ tree and point the storage paths at tmp_path.
+
+    Returns a callable ``write_latest_build(metadata_dict)`` that writes latest-build.json,
+    plus the releases root path.
+    """
+    data_path = tmp_path / "data"
+    releases_path = tmp_path / "releases"
+
+    # Patch the path constants in the modules that read them at call time.
+    monkeypatch.setattr(local_storage, "INGESTS_DATA_PATH", data_path)
+    monkeypatch.setattr(local_storage, "INGESTS_RELEASES_PATH", releases_path)
+    monkeypatch.setattr(translator_ingest.release, "INGESTS_RELEASES_PATH", releases_path)
+    monkeypatch.setattr(translator_ingest.release, "INGESTS_RELEASES_URL", "http://example.test/releases")
+
+    # Create the merge directory and the source artifacts release_ingest reads.
+    build_metadata = PipelineMetadata(**BASE_METADATA)
+    merge_dir = (
+        data_path / SOURCE / build_metadata.source_version
+        / f"transform_{build_metadata.transform_version}"
+        / f"normalization_{build_metadata.get_composite_normalization_version()}"
+        / f"merge_{build_metadata.merging_code_version}"
+    )
+    merge_dir.mkdir(parents=True)
+    (merge_dir / "merged_nodes.jsonl").write_text('{"id": "X:1"}\n')
+    (merge_dir / "merged_edges.jsonl").write_text('{"subject": "X:1", "object": "X:2"}\n')
+    _write_json(merge_dir / "graph-metadata.json", {"@id": "original", "url": "original"})
+    _write_json(merge_dir / "testing_data.json", {"sample": True})
+
+    def write_latest_build(metadata_dict):
+        _write_json(data_path / SOURCE / "latest-build.json", metadata_dict)
+
+    return write_latest_build, releases_path
+
+
+def _read_latest_release(releases_path):
+    with (releases_path / SOURCE / "latest-release.json").open() as f:
+        return json.load(f)
+
+
+def test_release_ingest_first_release(release_env):
+    """The first release starts at 1.0.0, stamps release_date, and carries build_date through."""
+    write_latest_build, releases_path = release_env
+    write_latest_build({**BASE_METADATA, "build_version": "build1", "build_date": "2026-01-01"})
+
+    release_ingest(SOURCE)
+
+    release_metadata = _read_latest_release(releases_path)
+    assert release_metadata["release_version"] == "1.0.0"
+    assert release_metadata["build_version"] == "build1"
+    # build_date is preserved from the build; release_date is stamped now.
+    assert release_metadata["build_date"] == "2026-01-01"
+    assert release_metadata["release_date"] == current_iso_date()
+
+    # The versioned release directory and its compressed archive exist, and are copied to latest.
+    assert (releases_path / SOURCE / "1.0.0" / f"{SOURCE}.tar.zst").exists()
+    assert (releases_path / SOURCE / "latest" / f"{SOURCE}.tar.zst").exists()
+
+
+def test_release_ingest_bumps_patch_for_new_build(release_env):
+    """A second, different build released later bumps the patch version and updates the dates."""
+    write_latest_build, releases_path = release_env
+
+    write_latest_build({**BASE_METADATA, "build_version": "build1", "build_date": "2026-01-01"})
+    release_ingest(SOURCE)
+    assert _read_latest_release(releases_path)["release_version"] == "1.0.0"
+
+    # New build version -> new release. Distinct release directories avoid same-day collisions.
+    write_latest_build({**BASE_METADATA, "build_version": "build2", "build_date": "2026-02-02"})
+    release_ingest(SOURCE)
+
+    release_metadata = _read_latest_release(releases_path)
+    assert release_metadata["release_version"] == "1.0.1"
+    assert release_metadata["build_version"] == "build2"
+    assert release_metadata["build_date"] == "2026-02-02"
+    assert (releases_path / SOURCE / "1.0.1" / f"{SOURCE}.tar.zst").exists()
+
+
+def test_release_ingest_same_build_is_noop(release_env):
+    """Re-releasing an unchanged build does not advance the release version."""
+    write_latest_build, releases_path = release_env
+    write_latest_build({**BASE_METADATA, "build_version": "build1", "build_date": "2026-01-01"})
+
+    release_ingest(SOURCE)
+    release_ingest(SOURCE)
+
+    assert _read_latest_release(releases_path)["release_version"] == "1.0.0"

--- a/tests/unit/test_release_version.py
+++ b/tests/unit/test_release_version.py
@@ -1,0 +1,37 @@
+import pytest
+
+from translator_ingest.util.metadata import next_release_version
+
+
+@pytest.mark.parametrize(
+    "previous, expected",
+    [
+        # No prior release, or a prior release without a valid semantic version,
+        # starts versioning fresh at 1.0.0.
+        (None, "1.0.0"),
+        ("", "1.0.0"),
+        ("2026_06_10", "1.0.0"),  # legacy date-based version
+        ("v1.0.0", "1.0.0"),  # leading 'v' is not valid semver here
+        ("1.0", "1.0.0"),  # not MAJOR.MINOR.PATCH
+        ("1.0.0-rc1", "1.0.0"),  # pre-release suffix not supported
+        # A valid semantic version bumps the patch component.
+        ("1.0.0", "1.0.1"),
+        ("1.0.1", "1.0.2"),
+        ("1.2.9", "1.2.10"),  # patch does not roll over into minor
+        ("2.5.99", "2.5.100"),
+        ("10.20.30", "10.20.31"),
+    ],
+)
+def test_next_release_version(previous, expected):
+    """The patch component is bumped, or versioning starts at 1.0.0 when no
+    valid semantic version precedes it."""
+    assert next_release_version(previous) == expected
+
+
+def test_next_release_version_is_repeatable():
+    """Repeated calls on subsequent versions produce a monotonic patch sequence."""
+    version = next_release_version(None)
+    assert version == "1.0.0"
+    for expected in ("1.0.1", "1.0.2", "1.0.3"):
+        version = next_release_version(version)
+        assert version == expected


### PR DESCRIPTION
This switches from date based release versioning to semantic versioning; and adds an explicit date field for build and release dates in metadata files.

Date based versioning was problematic - it prevented multiple releases of the same graph on the same day, and we already hit that issue once, so a change is necessary.

This implementation does not attempt to do anything intelligent about handling major and minor versions - releases starts at 1.0.0 and then bump the patch with each subsequent release. We will want to address that and implement some way to handle minor and major bumps later.

Previously, we were concerned about semantic versioning requiring a centralized and persistent storage for the pipeline for semantic versions to be valid/useful. This is still relevant but we just need to understand that release versions are tied to specific installations of translator-ingests and cannot be mixed or compared across different deployments/storage instances, such as in development. As we do have one centralized deployment now, this should not be an issue for translator.

Semantic versioning can also affect string based sorting of version directories. Currently we don't have cases where this will cause problems.