### PR TITLE
STRING in translator_kg

### DIFF
--- a/graphs.yaml
+++ b/graphs.yaml
@@ -43,7 +43,6 @@ graphs:
       - semmeddb
       - sider
       - signor
-      - string
       - tmkp
       - ttd
       - ubergraph


### PR DESCRIPTION
STRING was added to the main graph in graphs.yaml but it hadn't gone through QA and vetting yet, this removes it from the graph but keeps the ingest in the repo for now.