### PR TITLE
fixing CTD chem gene ixns edge direction bug

### DIFF
--- a/src/translator_ingest/ingests/ctd/ctd.py
+++ b/src/translator_ingest/ingests/ctd/ctd.py
@@ -216,7 +216,12 @@ def transform_chem_gene_ixns(koza: koza.KozaTransform, record: dict[str, Any]) -
     if chemical_is_subject and gene_is_subject:
         # There are some records where one name is a subset of the other (e.g. chem "NAD" vs gene "NADK");
         # So the startswith check triggers for both entities. Currently, there are only 6 of these and the
-        # longer string is always the real subject but this could result in bugs in the future
+        # longer string is always the real subject but this could result in bugs in the future.
+        #
+        # Note that this sounds really dumb, but it actually is hard to disambiguate them, see this example:
+        #   ChemicalName: SIRT3 inhibitor 3-TYP
+        #   GeneSymbol:   SIRT3
+        #   Interaction:  SIRT3 inhibitor 3-TYP results in decreased expression of SIRT3 protein
         chemical_is_subject = len(chemical_name) >= len(gene_symbol)
         gene_is_subject = not chemical_is_subject
     if not (chemical_is_subject or gene_is_subject):

--- a/src/translator_ingest/ingests/ctd/ctd.py
+++ b/src/translator_ingest/ingests/ctd/ctd.py
@@ -16,6 +16,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     Disease,
     DirectionQualifierEnum,
     Gene,
+    GeneAffectsChemicalAssociation,
     GeneOrGeneProductOrChemicalEntityAspectEnum,
     Pathway,
     PhenotypicFeature,
@@ -203,8 +204,27 @@ def transform_chem_gene_ixns(koza: koza.KozaTransform, record: dict[str, Any]) -
     interaction = interactions[0]
     interaction_direction, interaction_aspect = interaction.split("^")
 
-    predicate = BIOLINK_AFFECTS
-    qualified_predicate = BIOLINK_CAUSES
+    # CTD builds the human-readable Interaction sentence as "<subject> <action> ... of <object>",
+    # This direction is per-record, not per-aspect: e.g. "<chem> results in increased expression of <gene>" is
+    # chemical->gene, while "<gene> protein results in increased transport of <chem>" is gene->chemical. The aspect
+    # and direction qualifiers always describe the object, so they attach correctly once the orientation is set.
+    interaction_sentence = record['Interaction']
+    chemical_name = record['ChemicalName']
+    gene_symbol = record['GeneSymbol']
+    chemical_is_subject = interaction_sentence.startswith(chemical_name)
+    gene_is_subject = interaction_sentence.startswith(gene_symbol)
+    if chemical_is_subject and gene_is_subject:
+        # There are some records where one name is a subset of the other (e.g. chem "NAD" vs gene "NADK");
+        # So the startswith check triggers for both entities. Currently, there are only 6 of these and the
+        # longer string is always the real subject but this could result in bugs in the future
+        chemical_is_subject = len(chemical_name) >= len(gene_symbol)
+        gene_is_subject = not chemical_is_subject
+    if not (chemical_is_subject or gene_is_subject):
+        # the sentence starts with neither entity, meaning it describes a multi-entity interaction
+        # (e.g. "[<chem> results in ... of <intermediate>] which results in ... of <gene>") that we can't
+        # split into a single self-contained edge, so drop it like the multi-action records above.
+        return None
+
     object_direction_qualifier = None
     object_aspect_qualifier = None
 
@@ -317,12 +337,19 @@ def transform_chem_gene_ixns(koza: koza.KozaTransform, record: dict[str, Any]) -
 
     publications = [f'PMID:{pmid}' for pmid in record['PubMedIDs'].split('|')]
 
-    association = ChemicalAffectsGeneAssociation(
+    # The predicate is always affects/causes; only the subject/object orientation (decided above) differs.
+    if chemical_is_subject:
+        association_class = ChemicalAffectsGeneAssociation
+        subject_id, object_id = chemical_id, gene_id
+    else:
+        association_class = GeneAffectsChemicalAssociation
+        subject_id, object_id = gene_id, chemical_id
+
+    association = association_class(
         id=entity_id(),
-        subject=chemical_id,
-        predicate=predicate,
-        object=gene_id,
-        qualified_predicate=qualified_predicate,
+        subject=subject_id,
+        predicate=BIOLINK_AFFECTS,
+        object=object_id,
         sources=CTD_SOURCES,
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
@@ -333,6 +360,8 @@ def transform_chem_gene_ixns(koza: koza.KozaTransform, record: dict[str, Any]) -
         association.object_aspect_qualifier = object_aspect_qualifier
     if object_direction_qualifier:
         association.object_direction_qualifier = object_direction_qualifier
+        # qualified_predicate (causes) only applies when the effect has a direction (increased/decreased)
+        association.qualified_predicate = BIOLINK_CAUSES
 
     return KnowledgeGraph(nodes=[ChemicalEntity(id=chemical_id),
                                  Gene(id=gene_id)],

--- a/tests/unit/ingests/ctd/test_ctd.py
+++ b/tests/unit/ingests/ctd/test_ctd.py
@@ -1,6 +1,7 @@
 import pytest
 from biolink_model.datamodel.pydanticmodel_v2 import (
     ChemicalAffectsGeneAssociation,
+    GeneAffectsChemicalAssociation,
     ChemicalEntityToBiologicalProcessAssociation,
     ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation,
     ChemicalEntityToPathwayAssociation,
@@ -380,7 +381,89 @@ def test_chem_gene_ixns_affects_phosphorylation(chem_gene_ixns_affects_phosphory
     assert len(entities) == 3
     association = [e for e in entities if isinstance(e, ChemicalAffectsGeneAssociation)][0]
     assert association.object_direction_qualifier is None  # 'affects' doesn't set direction
+    # qualified_predicate (causes) only applies when a direction is present
+    assert association.qualified_predicate is None
     assert association.object_aspect_qualifier == GeneOrGeneProductOrChemicalEntityAspectEnum.phosphorylation
+
+
+@pytest.fixture
+def chem_gene_ixns_gene_subject_output():
+    """A record where the gene/enzyme is the actor on the chemical (gene -> chemical)."""
+    writer = MockKozaWriter()
+    record = {
+        "ChemicalName": "10,11-dihydro-10-hydroxycarbamazepine",
+        "ChemicalID": "C039775",
+        "CasRN": "",
+        "GeneSymbol": "ABCB1",
+        "GeneID": "5243",
+        "GeneForms": "protein",
+        "Organism": "Homo sapiens",
+        "OrganismID": "9606",
+        "Interaction": "ABCB1 protein results in increased transport of 10,11-dihydro-10-hydroxycarbamazepine",
+        "InteractionActions": "increases^transport",
+        "PubMedIDs": "12121212",
+    }
+    runner = KozaRunner(
+        data=[record],
+        writer=writer,
+        hooks=KozaTransformHooks(
+            on_data_begin=[on_chem_gene_ixns_begin],
+            transform_record=[transform_chem_gene_ixns]
+        )
+    )
+    runner.run()
+    return writer.items
+
+
+def test_chem_gene_ixns_gene_subject(chem_gene_ixns_gene_subject_output):
+    # The sentence starts with the gene, so the gene is the subject and the chemical is the object.
+    entities = chem_gene_ixns_gene_subject_output
+    assert len(entities) == 3  # chemical, gene, association
+    # it should be a Gene -> Chemical association, not Chemical -> Gene
+    assert not any(isinstance(e, ChemicalAffectsGeneAssociation) for e in entities)
+    association = [e for e in entities if isinstance(e, GeneAffectsChemicalAssociation)][0]
+    assert association.predicate == BIOLINK_AFFECTS
+    assert association.qualified_predicate == BIOLINK_CAUSES
+    assert association.subject == "NCBIGene:5243"
+    assert association.object == "MESH:C039775"
+    assert association.object_direction_qualifier == DirectionQualifierEnum.increased
+    # the aspect qualifies the object (the chemical being transported)
+    assert association.object_aspect_qualifier == GeneOrGeneProductOrChemicalEntityAspectEnum.transport
+
+
+@pytest.fixture
+def chem_gene_ixns_multi_entity_output():
+    """A single-action record whose sentence describes 3+ entities cannot be split into one edge -> skipped."""
+    writer = MockKozaWriter()
+    record = {
+        "ChemicalName": "1,3-di(1H-indol-3-yl)propan-2-one",
+        "ChemicalID": "C000000",
+        "CasRN": "",
+        "GeneSymbol": "DAO",
+        "GeneID": "1610",
+        "GeneForms": "protein",
+        "Organism": "Homo sapiens",
+        "OrganismID": "9606",
+        "Interaction": "[DAO protein results in increased chemical synthesis of indol-3-yl pyruvic acid] "
+                       "which results in increased chemical synthesis of 1,3-di(1H-indol-3-yl)propan-2-one",
+        "InteractionActions": "increases^chemical synthesis",
+        "PubMedIDs": "14141414",
+    }
+    runner = KozaRunner(
+        data=[record],
+        writer=writer,
+        hooks=KozaTransformHooks(
+            on_data_begin=[on_chem_gene_ixns_begin],
+            transform_record=[transform_chem_gene_ixns]
+        )
+    )
+    runner.run()
+    return writer.items
+
+
+def test_chem_gene_ixns_multi_entity_skipped(chem_gene_ixns_multi_entity_output):
+    # the sentence starts with neither this record's chemical nor gene -> dropped
+    assert len(chem_gene_ixns_multi_entity_output) == 0
 
 
 @pytest.fixture


### PR DESCRIPTION
This fixes a bug where 2% of the chemical to gene interaction edges were previously produced with the wrong direction (subject and object flipped).

The other 98% of two entity interactions are something like chemical -> interaction phrase -> gene so the ingest was previously written to assume that direction but 2% are gene -> interaction phrase -> chemical.

The proper direction can be derived by looking at which entity is mentioned at the beginning of the interaction sentence. There is no other way because the predicates/interactions can be used in either direction. 

There are 6 records where it is somewhat ambiguous because the names of the two entities start with the same letters. A rule was applied that currently applies the right direction for these cases but it's brittle.

Note that switching over to parsing the XML file for this part of CTD could probably make determining direction more reliable, but that would be a significant refactor and would likely break the streaming functionality of this ingest.

