### PR TITLE
CTD Sensitivity edges 

### DIFF
--- a/src/translator_ingest/ingests/ctd/ctd.py
+++ b/src/translator_ingest/ingests/ctd/ctd.py
@@ -13,6 +13,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import (
     ChemicalEntityToBiologicalProcessAssociation,
     ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation,
     ChemicalEntityToPathwayAssociation,
+    Association,
     Disease,
     DirectionQualifierEnum,
     Gene,
@@ -39,6 +40,17 @@ BIOLINK_CORRELATED_WITH = "biolink:correlated_with"
 BIOLINK_POSITIVELY_CORRELATED = "biolink:positively_correlated_with"
 BIOLINK_NEGATIVELY_CORRELATED = "biolink:negatively_correlated_with"
 BIOLINK_TREATS_OR_APPLIED_OR_STUDIED_TO_TREAT = "biolink:treats_or_applied_or_studied_to_treat"
+BIOLINK_AFFECTS_SENSITIVITY_TO = "biolink:affects_sensitivity_to"
+BIOLINK_INCREASES_SENSITIVITY_TO = "biolink:increases_sensitivity_to"
+BIOLINK_DECREASES_SENSITIVITY_TO = "biolink:decreases_sensitivity_to"
+
+# CTD's "response to substance" interaction action maps to the sensitivity predicates, with the direction
+# carried by the predicate itself (not a qualifier).
+SENSITIVITY_PREDICATES = {
+    "affects": BIOLINK_AFFECTS_SENSITIVITY_TO,
+    "increases": BIOLINK_INCREASES_SENSITIVITY_TO,
+    "decreases": BIOLINK_DECREASES_SENSITIVITY_TO,
+}
 
 CHEM_TO_DISEASE_PREDICATES = {
     "therapeutic": BIOLINK_TREATS_OR_APPLIED_OR_STUDIED_TO_TREAT,
@@ -230,6 +242,32 @@ def transform_chem_gene_ixns(koza: koza.KozaTransform, record: dict[str, Any]) -
         # split into a single self-contained edge, so drop it like the multi-action records above.
         return None
 
+    subject_id, object_id = (chemical_id, gene_id) if chemical_is_subject else (gene_id, chemical_id)
+    publications = [f'PMID:{pmid}' for pmid in record['PubMedIDs'].split('|')]
+
+    # CTD's "response to substance" action describes susceptibility ("... affects/increases/decreases the
+    # susceptibility to ..."), which Biolink models with the (affects|increases|decreases)_sensitivity_to
+    # predicates rather than an affects+aspect qualifier - the direction is carried by the predicate itself.
+    # No Biolink chemical<->gene association class accepts these predicates, so a generic Association is used;
+    # this means the species/taxon context can't be attached the way it is on the affects/causes edges below.
+    if interaction_aspect == 'response to substance':
+        sensitivity_predicate = SENSITIVITY_PREDICATES.get(interaction_direction)
+        if sensitivity_predicate is None:
+            koza.transform_metadata['unmapped_chem_gene_ixns'].add(interaction)
+            return None
+        association = Association(
+            id=entity_id(),
+            subject=subject_id,
+            predicate=sensitivity_predicate,
+            object=object_id,
+            sources=CTD_SOURCES,
+            knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+            agent_type=AgentTypeEnum.manual_agent,
+            publications=publications,
+        )
+        return KnowledgeGraph(nodes=[ChemicalEntity(id=chemical_id), Gene(id=gene_id)],
+                              edges=[association])
+
     object_direction_qualifier = None
     object_aspect_qualifier = None
 
@@ -340,16 +378,8 @@ def transform_chem_gene_ixns(koza: koza.KozaTransform, record: dict[str, Any]) -
         case _:
             koza.transform_metadata['unmapped_chem_gene_ixns'].add(interaction)
 
-    publications = [f'PMID:{pmid}' for pmid in record['PubMedIDs'].split('|')]
-
     # The predicate is always affects/causes; only the subject/object orientation (decided above) differs.
-    if chemical_is_subject:
-        association_class = ChemicalAffectsGeneAssociation
-        subject_id, object_id = chemical_id, gene_id
-    else:
-        association_class = GeneAffectsChemicalAssociation
-        subject_id, object_id = gene_id, chemical_id
-
+    association_class = ChemicalAffectsGeneAssociation if chemical_is_subject else GeneAffectsChemicalAssociation
     association = association_class(
         id=entity_id(),
         subject=subject_id,

--- a/tests/unit/ingests/ctd/test_ctd.py
+++ b/tests/unit/ingests/ctd/test_ctd.py
@@ -1,5 +1,6 @@
 import pytest
 from biolink_model.datamodel.pydanticmodel_v2 import (
+    Association,
     ChemicalAffectsGeneAssociation,
     GeneAffectsChemicalAssociation,
     ChemicalEntityToBiologicalProcessAssociation,
@@ -26,6 +27,9 @@ from translator_ingest.ingests.ctd.ctd import (
     on_chem_gene_ixns_begin,
     on_pheno_ixns_begin,
     BIOLINK_AFFECTS,
+    BIOLINK_AFFECTS_SENSITIVITY_TO,
+    BIOLINK_INCREASES_SENSITIVITY_TO,
+    BIOLINK_DECREASES_SENSITIVITY_TO,
     BIOLINK_ASSOCIATED_WITH,
     BIOLINK_CAUSES,
     BIOLINK_CORRELATED_WITH,
@@ -464,6 +468,80 @@ def chem_gene_ixns_multi_entity_output():
 def test_chem_gene_ixns_multi_entity_skipped(chem_gene_ixns_multi_entity_output):
     # the sentence starts with neither this record's chemical nor gene -> dropped
     assert len(chem_gene_ixns_multi_entity_output) == 0
+
+
+def _run_chem_gene(record):
+    writer = MockKozaWriter()
+    runner = KozaRunner(
+        data=[record],
+        writer=writer,
+        hooks=KozaTransformHooks(
+            on_data_begin=[on_chem_gene_ixns_begin],
+            transform_record=[transform_chem_gene_ixns]
+        )
+    )
+    runner.run()
+    return writer.items
+
+
+@pytest.mark.parametrize(
+    "direction,expected_predicate",
+    [
+        ("affects", BIOLINK_AFFECTS_SENSITIVITY_TO),
+        ("increases", BIOLINK_INCREASES_SENSITIVITY_TO),
+        ("decreases", BIOLINK_DECREASES_SENSITIVITY_TO),
+    ],
+)
+def test_chem_gene_ixns_response_to_substance_gene_subject(direction, expected_predicate):
+    # "response to substance" -> sensitivity predicates; here the gene is the actor (gene -> chemical).
+    verb = {"affects": "affects the", "increases": "results in increased", "decreases": "results in decreased"}[direction]
+    record = {
+        "ChemicalName": "10-hydroxycamptothecin",
+        "ChemicalID": "C098920",
+        "CasRN": "",
+        "GeneSymbol": "BCL2",
+        "GeneID": "596",
+        "GeneForms": "protein",
+        "Organism": "Homo sapiens",
+        "OrganismID": "9606",
+        "Interaction": f"BCL2 protein {verb} susceptibility to 10-hydroxycamptothecin",
+        "InteractionActions": f"{direction}^response to substance",
+        "PubMedIDs": "15151515",
+    }
+    entities = _run_chem_gene(record)
+    assert len(entities) == 3  # chemical, gene, association
+    # generic Association (no chemical<->gene sensitivity class exists), not an affects/causes class
+    assert not any(isinstance(e, (ChemicalAffectsGeneAssociation, GeneAffectsChemicalAssociation)) for e in entities)
+    association = [e for e in entities if isinstance(e, Association)][0]
+    assert association.predicate == expected_predicate
+    assert association.subject == "NCBIGene:596"
+    assert association.object == "MESH:C098920"
+    # direction is carried by the predicate, so the generic Association has no qualifier slots to populate
+    assert not hasattr(association, "qualified_predicate")
+    assert not hasattr(association, "object_direction_qualifier")
+    assert "PMID:15151515" in association.publications
+
+
+def test_chem_gene_ixns_response_to_substance_chemical_subject():
+    # the chemical can also be the actor (chemical -> gene)
+    record = {
+        "ChemicalName": "15-deoxy-delta(12,14)-prostaglandin J2",
+        "ChemicalID": "C088349",
+        "CasRN": "",
+        "GeneSymbol": "INS",
+        "GeneID": "3630",
+        "GeneForms": "protein",
+        "Organism": "Homo sapiens",
+        "OrganismID": "9606",
+        "Interaction": "15-deoxy-delta(12,14)-prostaglandin J2 results in decreased susceptibility to INS protein",
+        "InteractionActions": "decreases^response to substance",
+        "PubMedIDs": "16161616",
+    }
+    entities = _run_chem_gene(record)
+    association = [e for e in entities if isinstance(e, Association)][0]
+    assert association.predicate == BIOLINK_DECREASES_SENSITIVITY_TO
+    assert association.subject == "MESH:C088349"
+    assert association.object == "NCBIGene:3630"
 
 
 @pytest.fixture


### PR DESCRIPTION
Previously we weren't producing chemical-gene affects/decreases/increases sensitivity edges even though we wanted to (see #227 for some discussion) because they did not fit into the clean predicate/qualifier mappings that all of the other edges from the chemical gene ixn file did. 

I looked closer and see that 'response to substance' interactions can be mapped to the sensitivity predicates, they just need to follow a different path without qualifiers.

Unfortunately, the biolink model does not currently support a Chemical & Gene association type with the appropriate predicates affects_sensitivity_to, increases_sensitivity_to and decreases_sensitivity_to so a generic Association is used here instead. This has the side effect that the species_context_qualifier we normally put on these chemical gene interaction edges cannot be used.

So we need to decide if we'd prefer to update the biolink model to support these edges first and then update this ingest accordingly, or push through these edges now without species_context_qualifiers and update the model etc later.