### PR TITLE
Alliance RIG review & completion (#408)

### DIFF
--- a/src/translator_ingest/ingests/alliance/alliance_rig.yaml
+++ b/src/translator_ingest/ingests/alliance/alliance_rig.yaml
@@ -5,7 +5,7 @@ name: Alliance of Genome Resources (AGR) Reference Ingest Guide
 source_info:
   infores_id: infores:agrkb
   name: Alliance of Genome Resources (AGR)
-  description: "The Alliance of Genome Resources (AGR) is a consortium of model organism databases and the Gene Ontology Consortium that provides a unified view of gene function, biological processes, phenotypes, and disease associations across multiple model organisms. The AGR aggregates and harmonizes data from member databases including MGI (mouse), RGD (rat), SGD (yeast), WormBase (C. elegans), FlyBase (D. melanogaster), ZFIN (zebrafish), and Xenbase (X. laevis and X. tropicalis)."
+  description: "The Alliance of Genome Resources (AGR) is an international consortium of model organism databases and the Gene Ontology Consortium, coordinated through Alliance Central and supported primarily by the U.S. National Institutes of Health (NIH). It provides a unified, cross-species knowledge resource that enables researchers to compare genes, genomes, phenotypes, diseases, and biological functions across human and major model organisms, aggregating and harmonizing data from member databases including MGI (mouse), RGD (rat), SGD (yeast), WormBase (C. elegans), FlyBase (D. melanogaster), ZFIN (zebrafish), and Xenbase (X. laevis and X. tropicalis). AGR provides harmonized information on genes, alleles, variants, orthology, gene function, phenotypes, disease associations, gene expression, pathways, and molecular and genetic interactions. Its knowledge is generated through integration and harmonization of manually curated data from participating organism databases, incorporation of selected information from external resources, standardized computational analyses such as orthology inference, and automated data-processing pipelines; machine-learning- and text-mining-assisted workflows support literature curation, while biological annotations remain the product of expert curation."
   citations:
     - "Alliance of Genome Resources Portal: enhancing a MOD resource. Nucleic Acids Res. 2020 Jan 8;48(D1):D650-D658. PMID: 31691787"
     - "https://www.alliancegenome.org/"
@@ -22,6 +22,7 @@ source_info:
     - json
     - tsv
   data_versioning_and_releases: "The Alliance releases data in numbered versions (e.g., 7.0.0, 7.1.0) approximately every 2-3 months. Each release is archived and accessible via the FMS. Release information is available at https://www.alliancegenome.org/downloads and version metadata can be retrieved from the API at https://www.alliancegenome.org/api/releaseInfo."
+  source_status: maintained_regular_updates
 
 # Information about Ingested Content
 ingest_info:
@@ -97,7 +98,6 @@ ingest_info:
 
 # Information about the Graph Output by the ingest
 target_info:
-  infores_id: infores:translator-agr-kgx
 
   edge_type_info:
     - subject_categories:


### PR DESCRIPTION
Completes the RIG review for the **Alliance of Genome Resources (AGR)** ingest — the sub-issue #408 of the June 2026 RIG review campaign (epic #407).

## Changes to `alliance_rig.yaml`

- **Add `source_status: maintained_regular_updates`** — now a required `source_info` field (introduced in #391). AGR ships numbered releases roughly every 2–3 months.
- **Remove `target_info.infores_id`** — per the updated RIG conventions in the campaign guidance.
- **Expand `source_info.description`** — adapted from the campaign's LLM-generated resource description for a more complete, consistent overview of AGR (member DBs, content types, and how knowledge is generated).

## Already in place (from the earlier QC pass)

The accuracy/completeness items from the Feb 2026 Alliance QC were already reflected in the RIG and are unchanged here: `primary_knowledge_sources` / `aggregator_knowledge_sources`, `source_files`, EMAPA-only / MP-only node prefixes, the UBERON `stage_qualifier`, and the `MMO:0000658` assay example. The corresponding code fix (`stageUberonSlimTerm.uberonTerm` extraction, `_normalize_stage_term`, dropped `crossReference.id`) is likewise already merged in `alliance.py`.

## Checklist status (per #408)

- `supporting_data_source_info` — N/A (AGR is not a data-derived Translator source)
- `source_info.description` — expanded ✅
- `terms_of_use_info` — present (CC0); final license pass owned by Shilpa
- `source_status` — added ✅
- `target_info.infores_id` — removed ✅
- `edge_type_info` (both edge types): `knowledge_level`, `agent_type`, `primary_knowledge_sources`, `aggregator_knowledge_sources`, `edge_properties`, `ui_explanation`, `additional_notes`, `source_files`, `future_considerations` — all present ✅

## Validation

RIG YAML parses cleanly and the 8 alliance unit tests pass. Note: `make validate-rigs` currently can't run locally against the new `source_status` field — the pinned `resource-ingest-guide-schema` (0.1.3) predates it and has no `cli` module; the schema-package bump is a separate follow-up. No repo code parses RIGs through the pydantic model, so this change does not affect tests/CI.

Closes #408

