### PR TITLE
Fix get_latest_version() for bgee, go_cam, and goa (#445)

### DIFF
--- a/src/translator_ingest/ingests/bgee/bgee.py
+++ b/src/translator_ingest/ingests/bgee/bgee.py
@@ -25,8 +25,10 @@ BGEE_SOURCES = build_association_knowledge_sources(primary=INFORES_BGEE)
 def get_latest_version() -> str:
     """Get version from the manifest file"""
     latest_release_url = "https://www.bgee.org/ftp/release_v2.tsv"
+    # bgee.org returns HTTP 403 for the default Python urllib User-Agent, so send a browser-like one.
+    request = urllib.request.Request(latest_release_url, headers={"User-Agent": "Mozilla/5.0"})
     try:
-        with urllib.request.urlopen(latest_release_url) as response:
+        with urllib.request.urlopen(request) as response:
             response_text = response.read().decode('utf8')
             reader = list(csv.DictReader(response_text.splitlines(),delimiter='\t'))
             version = reader[0]['release']

--- a/src/translator_ingest/ingests/go_cam/go_cam.py
+++ b/src/translator_ingest/ingests/go_cam/go_cam.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from typing import Any, Iterable
 
 import koza
-import requests
 
+from translator_ingest.util.http_utils import get_geneontology_release_version
 from translator_ingest.util.transform_utils import entity_id
 from biolink_model.datamodel.pydanticmodel_v2 import (
     Gene,
@@ -24,25 +24,13 @@ from translator_ingest.util.logging_utils import get_logger
 # Constants
 INFORES_GO_CAM = "infores:go-cam"
 INFORES_REACTOME = "infores:reactome"
-GOA_RELEASE_METADATA_URL = "https://current.geneontology.org/metadata/release-date.json"
 
 logger = get_logger(__name__)
 
 
 def get_latest_version() -> str:
     """Fetch the current GO release version from the public metadata endpoint."""
-    try:
-        response = requests.get(GOA_RELEASE_METADATA_URL, timeout=10)
-        response.raise_for_status()
-        metadata = response.json()
-    except requests.RequestException as exc:
-        raise RuntimeError(f"Unable to retrieve GO release metadata from {GOA_RELEASE_METADATA_URL}") from exc
-
-    version = metadata.get("date")
-    if not version:
-        raise RuntimeError(f"GO metadata from {GOA_RELEASE_METADATA_URL} did not include a 'date' field")
-
-    return version
+    return get_geneontology_release_version()
 
 
 def extract_value(value):

--- a/src/translator_ingest/ingests/goa/goa.py
+++ b/src/translator_ingest/ingests/goa/goa.py
@@ -1,7 +1,6 @@
 from typing import Iterable, Any
 
 import koza
-import requests
 
 from biolink_model.datamodel.pydanticmodel_v2 import (
     Gene,
@@ -23,9 +22,7 @@ from koza.model.graphs import KnowledgeGraph
 from translator_ingest.util.biolink import build_association_knowledge_sources
 from translator_ingest.util.transform_utils import entity_id
 from translator_ingest.util.biolink import INFORES_GOA, INFORES_INTACT
-
-# Constants
-GOA_RELEASE_METADATA_URL = "https://current.geneontology.org/metadata/release-date.json"
+from translator_ingest.util.http_utils import get_geneontology_release_version
 
 # Supporting source mapping based on GOA `Assigned_By` field.
 # We only map values with clear upstream source identity.
@@ -42,18 +39,7 @@ ASSIGNED_BY_TO_SUPPORTING_INFORES = {
 
 def get_latest_version() -> str:
     """Fetch the current GOA release version from the public metadata endpoint."""
-    try:
-        response = requests.get(GOA_RELEASE_METADATA_URL, timeout=10)
-        response.raise_for_status()
-        metadata = response.json()
-    except requests.RequestException as exc:
-        raise RuntimeError(f"Unable to retrieve GOA release metadata from {GOA_RELEASE_METADATA_URL}") from exc
-
-    version = metadata.get("date")
-    if not version:
-        raise RuntimeError(f"GOA metadata from {GOA_RELEASE_METADATA_URL} did not include a 'date' field")
-
-    return version
+    return get_geneontology_release_version()
 
 
 # Dynamic category assignments from Biolink pydantic models

--- a/src/translator_ingest/util/http_utils.py
+++ b/src/translator_ingest/util/http_utils.py
@@ -1,5 +1,6 @@
 # HTTP query wrappers
 
+import re
 import requests
 import datetime
 from ftplib import FTP
@@ -9,6 +10,51 @@ from email.utils import parsedate_to_datetime
 from translator_ingest.util.logging_utils import get_logger
 
 logger = get_logger(__name__)
+
+# Public Gene Ontology release metadata endpoint, shared by the GO-CAM and GOA ingests.
+GENEONTOLOGY_RELEASE_METADATA_URL = "https://current.geneontology.org/metadata/release-date.json"
+_ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+
+
+def _extract_iso_date(text: str) -> str | None:
+    """Extract the first ``YYYY-MM-DD`` date from a string, or ``None`` if there isn't one.
+
+    The GO metadata endpoint returns malformed pseudo-JSON with an unquoted key and value,
+    so we can't use ``json.loads``; a plain regex extraction is robust to that.
+
+    >>> _extract_iso_date("{date: 2026-06-19}")
+    '2026-06-19'
+    >>> _extract_iso_date('{"date": "2026-06-19"}')
+    '2026-06-19'
+    >>> _extract_iso_date("no date here") is None
+    True
+    """
+    match = _ISO_DATE_RE.search(text)
+    return match.group(0) if match else None
+
+
+def get_geneontology_release_version(url: str = GENEONTOLOGY_RELEASE_METADATA_URL) -> str:
+    """Fetch the current Gene Ontology release date (YYYY-MM-DD).
+
+    The GO metadata endpoint returns malformed pseudo-JSON with an unquoted key and value
+    (e.g. ``{date: 2026-06-19}``), so ``response.json()`` raises ``JSONDecodeError``. We extract
+    the ISO date from the raw response text instead of parsing it as JSON.
+
+    :param url: GO release metadata endpoint (defaults to the public ``release-date.json``)
+    :return: the release date as a ``YYYY-MM-DD`` string
+    :raises RuntimeError: if the endpoint is unreachable or contains no ISO date
+    """
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise RuntimeError(f"Unable to retrieve GO release metadata from {url}") from exc
+
+    version = _extract_iso_date(response.text)
+    if not version:
+        raise RuntimeError(f"GO metadata from {url} did not contain a release date: {response.text!r}")
+
+    return version
 
 
 def post_query(url: str, query: dict, params=None, server: str = "") -> dict:


### PR DESCRIPTION
Fixes `get_latest_version()` for three of the four ingests reported in #445. Each failure was confirmed by calling the function directly.

## bgee — HTTP 403 (missing User-Agent)
`urllib.request.urlopen()` sent the default Python User-Agent, which bgee.org rejects with 403. Now sends `User-Agent: Mozilla/5.0`. Verified: returns `15.2`.

## go_cam / goa — malformed JSON from the GO metadata endpoint
Both fetch `https://current.geneontology.org/metadata/release-date.json` and called `response.json()`. That endpoint returns **invalid JSON** with an unquoted key and value:

```
{date: 2026-06-19}
```

`response.json()` raised `requests.exceptions.JSONDecodeError` (a subclass of `requests.RequestException`), which the `except requests.RequestException` block swallowed and re-raised as a generic "Unable to retrieve" RuntimeError — hiding the real cause.

Now the ISO date is extracted from the raw response text with a regex instead of JSON parsing. Since go_cam and goa duplicated the same URL constant and function verbatim, the fetch is factored into `get_geneontology_release_version()` in `util/http_utils.py`, with a testable pure `_extract_iso_date()` helper (doctested). Verified: both return `2026-06-19`.

## Not included: pathbank
PathBank (#445) is behind a Cloudflare managed challenge (`cf-mitigated: challenge`) that returns 403 to plain requests, browser-UA requests, and `curl_cffi` TLS impersonation, and also blocks the actual data download. It needs a separate strategy decision and is left open in #445.

## Testing
- New doctests on `_extract_iso_date` pass.
- All 113 existing bgee/go_cam/goa unit tests pass.
- Live verification of all three `get_latest_version()` functions.

Refs #445

https://claude.ai/code/session_01SLnBe9Wa7JFj87KoaRFdtk
