### PR TITLE
Bring in RIG schema 0.1.5 + fix validate-rigs (non-blocking)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
     "nbclassic",
     "jupyter_contrib_nbextensions",
     "jsonlines",
-    "resource-ingest-guide-schema",
+    "resource-ingest-guide-schema>=0.1.5",
     # Documentation dependencies
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.5.0",

--- a/rig.Makefile
+++ b/rig.Makefile
@@ -12,15 +12,20 @@ endif
 	$(RUN) python src/docs/scripts/create_rig.py --infores "$(INFORES)" --name "$(NAME)"
 
 # Validate all RIG files against the schema
+# Note: intentionally not wired into `make test`/CI yet - RIGs are being brought
+# into conformance with the released schema first (see conformance sweep).
 validate-rigs:
 	@echo "Validating RIG files against schema..."
-	@for rig_file in src/translator_ingest/ingests/*/*_rig.yaml; do \
+	@SCHEMA=$$($(RUN) python -c "from importlib.resources import files; print(files('resource_ingest_guide_schema').joinpath('schema/resource_ingest_guide_schema.yaml'))"); \
+	fail=0; \
+	for rig_file in src/translator_ingest/ingests/*/*_rig.yaml; do \
 		if [ -f "$$rig_file" ]; then \
 			echo "Validating $$rig_file"; \
-			$(RUN) python -m resource_ingest_guide_schema.cli validate "$$rig_file"; \
+			$(RUN) linkml-validate -s "$$SCHEMA" -C ReferenceIngestGuide "$$rig_file" || fail=1; \
 		fi; \
-	done
-	@echo "✓ All RIG files validated successfully"
+	done; \
+	if [ $$fail -ne 0 ]; then echo "✗ Some RIG files failed validation"; exit 1; fi; \
+	echo "✓ All RIG files validated successfully"
 
 # List all RIG files
 list-rigs:

--- a/uv.lock
+++ b/uv.lock
@@ -356,7 +356,7 @@ dev = [
     { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
     { name = "nbclassic" },
     { name = "pytest", specifier = ">=8.4.1" },
-    { name = "resource-ingest-guide-schema" },
+    { name = "resource-ingest-guide-schema", specifier = ">=0.1.5" },
     { name = "ruff", specifier = ">=0.12.8" },
 ]
 
@@ -948,7 +948,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/c8/9d76a66421d1ae24340dfae7e79c313957f6e3195c144d2c73333b5bfe34/greenlet-3.3.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7e806ca53acf6d15a888405880766ec84721aa4181261cd11a457dfe9a7a4975", size = 276443, upload-time = "2026-01-23T15:30:10.066Z" },
     { url = "https://files.pythonhosted.org/packages/81/99/401ff34bb3c032d1f10477d199724f5e5f6fbfb59816ad1455c79c1eb8e7/greenlet-3.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d842c94b9155f1c9b3058036c24ffb8ff78b428414a19792b2380be9cecf4f36", size = 597359, upload-time = "2026-01-23T16:00:57.394Z" },
     { url = "https://files.pythonhosted.org/packages/2b/bc/4dcc0871ed557792d304f50be0f7487a14e017952ec689effe2180a6ff35/greenlet-3.3.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20fedaadd422fa02695f82093f9a98bad3dab5fcda793c658b945fcde2ab27ba", size = 607805, upload-time = "2026-01-23T16:05:28.068Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/cd/7a7ca57588dac3389e97f7c9521cb6641fd8b6602faf1eaa4188384757df/greenlet-3.3.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c620051669fd04ac6b60ebc70478210119c56e2d5d5df848baec4312e260e4ca", size = 622363, upload-time = "2026-01-23T16:15:54.754Z" },
     { url = "https://files.pythonhosted.org/packages/cf/05/821587cf19e2ce1f2b24945d890b164401e5085f9d09cbd969b0c193cd20/greenlet-3.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14194f5f4305800ff329cbf02c5fcc88f01886cadd29941b807668a45f0d2336", size = 609947, upload-time = "2026-01-23T15:32:51.004Z" },
     { url = "https://files.pythonhosted.org/packages/a4/52/ee8c46ed9f8babaa93a19e577f26e3d28a519feac6350ed6f25f1afee7e9/greenlet-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7b2fe4150a0cf59f847a67db8c155ac36aed89080a6a639e9f16df5d6c6096f1", size = 1567487, upload-time = "2026-01-23T16:04:22.125Z" },
     { url = "https://files.pythonhosted.org/packages/8f/7c/456a74f07029597626f3a6db71b273a3632aecb9afafeeca452cfa633197/greenlet-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:49f4ad195d45f4a66a0eb9c1ba4832bb380570d361912fa3554746830d332149", size = 1636087, upload-time = "2026-01-23T15:33:47.486Z" },
@@ -957,7 +956,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/ab/d26750f2b7242c2b90ea2ad71de70cfcd73a948a49513188a0fc0d6fc15a/greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3", size = 275205, upload-time = "2026-01-23T15:30:24.556Z" },
     { url = "https://files.pythonhosted.org/packages/10/d3/be7d19e8fad7c5a78eeefb2d896a08cd4643e1e90c605c4be3b46264998f/greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac", size = 599284, upload-time = "2026-01-23T16:00:58.584Z" },
     { url = "https://files.pythonhosted.org/packages/ae/21/fe703aaa056fdb0f17e5afd4b5c80195bbdab701208918938bd15b00d39b/greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd", size = 610274, upload-time = "2026-01-23T16:05:29.312Z" },
-    { url = "https://files.pythonhosted.org/packages/06/00/95df0b6a935103c0452dad2203f5be8377e551b8466a29650c4c5a5af6cc/greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e", size = 624375, upload-time = "2026-01-23T16:15:55.915Z" },
     { url = "https://files.pythonhosted.org/packages/cb/86/5c6ab23bb3c28c21ed6bebad006515cfe08b04613eb105ca0041fecca852/greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3", size = 612904, upload-time = "2026-01-23T15:32:52.317Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f3/7949994264e22639e40718c2daf6f6df5169bf48fb038c008a489ec53a50/greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951", size = 1567316, upload-time = "2026-01-23T16:04:23.316Z" },
     { url = "https://files.pythonhosted.org/packages/8d/6e/d73c94d13b6465e9f7cd6231c68abde838bb22408596c05d9059830b7872/greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2", size = 1636549, upload-time = "2026-01-23T15:33:48.643Z" },
@@ -2906,7 +2904,7 @@ wheels = [
 
 [[package]]
 name = "resource-ingest-guide-schema"
-version = "0.1.3"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2915,9 +2913,9 @@ dependencies = [
     { name = "linkml-runtime" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/76/2d43a740849592f649c566500197019f248a1509c7458d5ba5334f4ca108/resource_ingest_guide_schema-0.1.3.tar.gz", hash = "sha256:1802d5eb0c335807c312d136dc580bf1fb7aea4403d48e7b3b6329927643ac0a", size = 2414423, upload-time = "2026-01-26T20:58:57.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/16/a8b30ac3e399dc5525532e0563959cb2059d1bbb84b5ccc34be52510bdc2/resource_ingest_guide_schema-0.1.5.tar.gz", hash = "sha256:2df384cb52d16034da65449402f8f2451b59c2e80e79e4c448dc9884c23233d7", size = 2465766, upload-time = "2026-07-09T15:23:16.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/c5/f184c4d43260c9ec193571c4819fffcb222ddfa2e52c468ba0397e20a887/resource_ingest_guide_schema-0.1.3-py3-none-any.whl", hash = "sha256:86a95607a7b584bc086ee9d66599f9225f1870283c65b87833ef02726909e2ae", size = 14906, upload-time = "2026-01-26T20:58:55.722Z" },
+    { url = "https://files.pythonhosted.org/packages/35/04/01e49294c5e1c350ca14fc57017dd57d93e35db37cb822945946a5f784b3/resource_ingest_guide_schema-0.1.5-py3-none-any.whl", hash = "sha256:568cb2834a060d72a538410cf0488ac8cd56cd97dcf1de4bdbb889fd94069bdd", size = 22151, upload-time = "2026-07-09T15:23:15.553Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Brings the released **resource-ingest-guide-schema 0.1.5** into the repo and makes `make validate-rigs` actually runnable. **Intentionally does not enable validation in CI** — that waits until RIGs are brought into conformance (see below).

## Changes

- **Pin `resource-ingest-guide-schema>=0.1.5`** (was unpinned, resolving to 0.1.3). 0.1.5 adds `source_status` + `SourceStatusEnum`, makes `included_content` optional, and makes `additional_notes` multivalued (schema PRs biolink/resource-ingest-guide-schema#48).
- **Fix the `validate-rigs` target.** It previously called `python -m resource_ingest_guide_schema.cli validate`, a module that doesn't exist in the published package (so the target never worked). Now uses `linkml-validate` against the packaged schema, resolved via `importlib.resources`.

## Why not enable it in CI now

`make test` (what CI runs) does **not** call `validate-rigs`, and this PR keeps it that way. Against 0.1.5, **all 32 RIGs currently fail** — but entirely on *mechanical schema-conformance* issues, not content:

| Fix class | RIGs |
|---|---|
| `additional_notes` → list | 22 |
| enum value corrections (data_formats, ingest_categories, future_considerations categories, provision_mechanisms) | 18 |
| `predicate` → `predicates` | 3 |
| `object` → `object_categories` | 3 |
| `node_categories` → `node_category` | 2 |
| `value_enumerations` → `value_enumeration` | 2 |
| `known_issues` (field not in schema) | 3 |

A follow-up conformance-sweep PR will bring all RIGs into line; `validate-rigs` can then be wired into CI as a gate. The per-ingest RIG *review* issues (#407 epic) are independent of this.

## Safety

Nothing in the ingest code parses RIGs through the schema at runtime, so bumping the pin is inert for the pipeline — it only affects the `validate-rigs` target.

https://claude.ai/code/session_017ieQfWcCiui8noimL1Y1Dy