### PR TITLE
RIG review: complete GO-CAM ingest guide (schema 0.1.5)

### DIFF
--- a/src/translator_ingest/ingests/go_cam/go_cam_rig.yaml
+++ b/src/translator_ingest/ingests/go_cam/go_cam_rig.yaml
@@ -5,7 +5,8 @@ name: Gene Ontology Causal Activity Models (GO-CAM) Reference Ingest Guide
 source_info:
   infores_id: infores:gocam
   name: Gene Ontology Causal Activity Models (GO-CAM)
-  description: "GO-CAM (Gene Ontology Causal Activity Models) is a framework that extends standard GO annotations by connecting molecular functions, biological processes, and cellular components into causally linked pathways. GO-CAMs provide explicit causal connections between gene products and their activities within specific biological contexts, enabling more detailed representation of biological mechanisms than traditional GO annotations."
+  description: "GO-CAM (Gene Ontology Causal Activity Models) is developed by the Gene Ontology Consortium as an extension of the GO knowledgebase. It provides computable mechanistic models representing how molecular activities are causally connected to form biological pathways and processes, supporting knowledge representation, computational reasoning, and pathway analysis. GO-CAM models describe molecular activities, biological processes, cellular components, gene products, causal relationships, and supporting evidence using semantic web technologies and biomedical ontologies. Knowledge is generated primarily through expert manual curation in which curators synthesize evidence from the literature into structured causal models, building on existing GO annotations; computational validation and ontology reasoning ensure logical consistency."
+  source_status: maintained_regular_updates
   citations:
     - "Thomas PD, Hill DP, Mi H, Osumi-Sutherland D, Van Auken K, Carbon S, Balhoff JP, Albou LP, Good B, Gaudet P, Lewis SE, Mungall CJ. Gene Ontology Causal Activity Modeling (GO-CAM) moves beyond GO annotations to structured descriptions of biological functions and systems. Nat Genet. 2019 Oct;51(10):1429-1433. doi: 10.1038/s41588-019-0500-1"
   terms_of_use_info:
@@ -72,8 +73,6 @@ ingest_info:
 
 # Information about the Graph Output by the ingest
 target_info:
-  infores_id: infores:translator-gocam-kgx
-
   edge_type_info:
     - subject_categories:
         - biolink:Gene
@@ -85,6 +84,11 @@ target_info:
         - knowledge_assertion
       agent_type:
         - manual_agent
+      primary_knowledge_sources:
+        - infores:go-cam
+        - infores:reactome
+      aggregator_knowledge_sources:
+        - infores:go-cam
       edge_properties:
         - model_id
         - source_gene_molecular_function
@@ -104,6 +108,11 @@ target_info:
         - knowledge_assertion
       agent_type:
         - manual_agent
+      primary_knowledge_sources:
+        - infores:go-cam
+        - infores:reactome
+      aggregator_knowledge_sources:
+        - infores:go-cam
       edge_properties:
         - model_id
         - source_gene_molecular_function
@@ -123,6 +132,11 @@ target_info:
         - knowledge_assertion
       agent_type:
         - manual_agent
+      primary_knowledge_sources:
+        - infores:go-cam
+        - infores:reactome
+      aggregator_knowledge_sources:
+        - infores:go-cam
       edge_properties:
         - model_id
         - source_gene_molecular_function
@@ -142,6 +156,11 @@ target_info:
         - knowledge_assertion
       agent_type:
         - manual_agent
+      primary_knowledge_sources:
+        - infores:go-cam
+        - infores:reactome
+      aggregator_knowledge_sources:
+        - infores:go-cam
       edge_properties:
         - model_id
         - source_gene_molecular_function
@@ -151,14 +170,17 @@ target_info:
         - target_gene_biological_process
         - target_gene_occurs_in
       ui_explanation: "GO-CAM models provide causal relationships where one gene product negatively regulates another gene product's activity, potentially through indirect mechanisms."
-      additional_notes: "GO-CAM predicates are mapped to Biolink regulation predicates based on the causal relationship types defined in the Relation Ontology (RO). All edges are manual agent knowledge assertions as GO-CAMs are manually curated models of biological mechanisms. Edge properties preserve the functional context (molecular function, biological process, cellular component) for both source and target genes."
+      additional_notes:
+        - "GO-CAM predicates are mapped to Biolink regulation predicates based on the causal relationship types defined in the Relation Ontology (RO). All edges are manual agent knowledge assertions as GO-CAMs are manually curated models of biological mechanisms. Edge properties preserve the functional context (molecular function, biological process, cellular component) for both source and target genes."
+        - "Most edges have infores:go-cam as their primary knowledge source. Edges derived from Reactome-sourced GO-CAM models (identified by an R-HSA pattern in the model id) instead have infores:reactome as their primary knowledge source, with infores:go-cam serving as an aggregator knowledge source."
 
   node_type_info:
     - node_category: biolink:Gene
       source_identifier_types:
         - "UniProtKB"
         - "MGI"
-      additional_notes: "Gene identifiers from human and mouse models only (NCBITaxon:9606, NCBITaxon:10090)"
+      additional_notes:
+        - "Gene identifiers from human and mouse models only (NCBITaxon:9606, NCBITaxon:10090)"
 
   future_considerations:
     - category: other


### PR DESCRIPTION
## June 2026 RIG review — GO-CAM (Gene Ontology Causal Activity Models)

Completes the RIG review for the **go_cam** ingest against **resource-ingest-guide-schema 0.1.5**. Validates cleanly with `linkml-validate -C ReferenceIngestGuide`.

### Changes to `go_cam_rig.yaml`
- **`source_info.source_status`** — added `maintained_regular_updates` (new GO-CAMs are added to the index weekly).
- **`target_info.infores_id`** — removed (kept `source_info.infores_id`).
- **`source_info.description`** — replaced with the authoritative GO Consortium description text.
- **Edge types (all 4)** — added the now-required `primary_knowledge_sources` (`infores:go-cam`, `infores:reactome`) and `aggregator_knowledge_sources` (`infores:go-cam`). Subject/object/predicate categories, `knowledge_level`, and `agent_type` were already plural lists; `ui_explanation` present on each.
- **Conformance** — converted `additional_notes` from strings to lists in the edge type and node type sections. `fields_used` already a string; `node_category` kept singular; `source_identifier_types` a list.

### Primary knowledge sources (derived from `go_cam.py`)
The transform assigns `infores:go-cam` as the primary knowledge source for most models. Models sourced from Reactome (identified by an `R-HSA-` pattern in the model id) instead use `infores:reactome` as primary with `infores:go-cam` as an aggregator. Both cases are captured on every edge type, with an explanatory `additional_notes` entry.

### Validation
```
linkml-validate -s resource_ingest_guide_schema.yaml -C ReferenceIngestGuide go_cam_rig.yaml
No issues found
```

Note: `source_info.infores_id` remains `infores:gocam` (kept per review scope); the primary knowledge source curie used in the transform code/data is `infores:go-cam`.

Closes #423

https://claude.ai/code/session_017ieQfWcCiui8noimL1Y1Dy