### PR TITLE
CTD binding edges

### DIFF
--- a/src/translator_ingest/ingests/ctd/ctd.py
+++ b/src/translator_ingest/ingests/ctd/ctd.py
@@ -10,6 +10,7 @@ import koza
 from biolink_model.datamodel.pydanticmodel_v2 import (
     ChemicalEntity,
     ChemicalAffectsGeneAssociation,
+    ChemicalGeneInteractionAssociation,
     ChemicalEntityToBiologicalProcessAssociation,
     ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation,
     ChemicalEntityToPathwayAssociation,
@@ -43,6 +44,7 @@ BIOLINK_TREATS_OR_APPLIED_OR_STUDIED_TO_TREAT = "biolink:treats_or_applied_or_st
 BIOLINK_AFFECTS_SENSITIVITY_TO = "biolink:affects_sensitivity_to"
 BIOLINK_INCREASES_SENSITIVITY_TO = "biolink:increases_sensitivity_to"
 BIOLINK_DECREASES_SENSITIVITY_TO = "biolink:decreases_sensitivity_to"
+BIOLINK_DIRECTLY_PHYSICALLY_INTERACTS_WITH = "biolink:directly_physically_interacts_with"
 
 # CTD's "response to substance" interaction action maps to the sensitivity predicates, with the direction
 # carried by the predicate itself (not a qualifier).
@@ -264,6 +266,23 @@ def transform_chem_gene_ixns(koza: koza.KozaTransform, record: dict[str, Any]) -
             knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
             agent_type=AgentTypeEnum.manual_agent,
             publications=publications,
+        )
+        return KnowledgeGraph(nodes=[ChemicalEntity(id=chemical_id), Gene(id=gene_id)],
+                              edges=[association])
+
+    # CTD's "binding" action ("<chem> binds to <gene>") "affects^binding" describes a direct physical interaction 
+    # with no asserted effect on the gene, it maps to the symmetric 'directly_physically_interacts_with'.
+    if interaction_aspect == 'binding':
+        association = ChemicalGeneInteractionAssociation(
+            id=entity_id(),
+            subject=subject_id,
+            predicate=BIOLINK_DIRECTLY_PHYSICALLY_INTERACTS_WITH,
+            object=object_id,
+            sources=CTD_SOURCES,
+            knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+            agent_type=AgentTypeEnum.manual_agent,
+            publications=publications,
+            species_context_qualifier=taxon_id,
         )
         return KnowledgeGraph(nodes=[ChemicalEntity(id=chemical_id), Gene(id=gene_id)],
                               edges=[association])

--- a/src/translator_ingest/ingests/ctd/ctd_rig.yaml
+++ b/src/translator_ingest/ingests/ctd/ctd_rig.yaml
@@ -185,14 +185,11 @@
         relevant_files: CTD_chem_go_enriched.tsv.gz, CTD_chem_pathways_enriched.tsv.gz
       - category:  edge_content
         consideration: >-
-          Five CTD chemical-gene interaction aspects have no Biolink aspect mapping in the transform, so records
-          carrying them currently become 'affects' edges with no aspect qualifier (they are counted as unmapped by
-          the transform). Among the single-action records that actually reach the transform these are: "binding"
-          (~10.5K records), "export" (~420), "import" (~185), "reaction" (~5), and "polymerization" (~2). "binding"
-          is the one that matters at scale and has a clean target - biolink:directly_physically_interacts_with,
-          which captures the interaction without asserting an effect on the gene. "export"/"import" could plausibly
-          map to a transport aspect with a direction. Until they are mapped, these edges silently understate what
-          CTD asserts.
+          A few CTD chemical-gene interaction aspects still have no Biolink mapping in the transform, so records
+          carrying them become 'affects' edges with no aspect qualifier (counted as unmapped by the transform).
+          Among the single-action records that reach the transform these are "export" (~420 records), "import"
+          (~185), "reaction" (~5), and "polymerization" (~2). "export"/"import" could plausibly map to a transport
+          aspect with a direction. These are low-volume, but until mapped they silently understate what CTD asserts.
         relevant_files: CTD_chem_gene_ixns.tsv.gz
       - category:  edge_content
         consideration: >-
@@ -321,7 +318,7 @@
         additional_notes:
           - CTD encodes each interaction as an InteractionActions value of the form "<direction>^<aspect>" (e.g. "increases^expression"). The direction becomes the object_direction_qualifier, and the aspect becomes the object_aspect_qualifier. 'qualified_predicate' is only set to 'biolink:causes' when the record carries a direction (increases/decreases) - an "affects^<aspect>" record yields a bare 'affects' edge with an aspect but no direction.
           - The subject/object orientation is not a separate column in CTD - it is recovered from CTD's human-readable Interaction sentence, which is always written as "<subject> <action> ... of <object>". Records whose sentence begins with the chemical produce this Chemical-Gene edge; records beginning with the gene symbol produce the Gene-Chemical edge described below.
-          - A handful of CTD aspects have no Biolink mapping in the transform - most notably "binding" (~10.5K records reaching the transform), plus "export", "import", "reaction", and "polymerization". Records carrying them surface here as 'affects' edges with no aspect qualifier, which understates what CTD asserts. See future considerations.
+          - A few low-volume aspects ("export", "import", "reaction", "polymerization") remain unmapped and surface here as 'affects' edges with no aspect qualifier; see future considerations.
 
       - subject_categories:
           - biolink:Gene
@@ -406,6 +403,32 @@
           - CTD_chem_gene_ixns.tsv.gz
         additional_notes:
           - This is the same "response to substance" content as the Gene-Chemical sensitivity edge above, with the orientation reversed - it is used for records whose Interaction sentence names the chemical as the subject. The same generic biolink:Association caveat applies, so these edges also carry no species context.
+
+      - subject_categories:
+          - biolink:ChemicalEntity
+          - biolink:MolecularMixture
+          - biolink:SmallMolecule
+        predicates:
+          - biolink:directly_physically_interacts_with
+        object_categories:
+          - biolink:Gene
+        qualifiers:
+          - property: biolink:species_context_qualifier
+            value_id_prefixes:
+              - NCBITaxon
+        knowledge_level:
+          - knowledge_assertion
+        agent_type:
+          - manual_agent
+        primary_knowledge_sources:
+          - infores:ctd
+        edge_properties:
+          - biolink:publications
+        ui_explanation: "Source CTD data provides assertions about Chemical-Gene relationships that were manually curated from literature by CTD. The CTD record used to create this edge reports that a chemical physically binds to a particular gene or gene product, without asserting any resulting effect on the gene. This is represented using the Biolink 'directly physically interacts with' predicate, which is symmetric. CTD reports these as its 'binding' interaction aspect (always as 'affects^binding', with no direction), so unlike the other chemical-gene edges these carry no aspect or direction qualifier."
+        source_files:
+          - CTD_chem_gene_ixns.tsv.gz
+        additional_notes:
+          - The subject/object orientation follows CTD's Interaction sentence ("<chemical> binds to <gene>" vs "<gene> protein binds to <chemical>"), as with the other chemical-gene edges. Because the predicate is symmetric the orientation carries no semantic weight, but it is preserved as reported.
 
       - subject_categories:
           - biolink:ChemicalEntity

--- a/tests/unit/ingests/ctd/test_ctd.py
+++ b/tests/unit/ingests/ctd/test_ctd.py
@@ -2,6 +2,7 @@ import pytest
 from biolink_model.datamodel.pydanticmodel_v2 import (
     Association,
     ChemicalAffectsGeneAssociation,
+    ChemicalGeneInteractionAssociation,
     GeneAffectsChemicalAssociation,
     ChemicalEntityToBiologicalProcessAssociation,
     ChemicalEntityToDiseaseOrPhenotypicFeatureAssociation,
@@ -30,6 +31,7 @@ from translator_ingest.ingests.ctd.ctd import (
     BIOLINK_AFFECTS_SENSITIVITY_TO,
     BIOLINK_INCREASES_SENSITIVITY_TO,
     BIOLINK_DECREASES_SENSITIVITY_TO,
+    BIOLINK_DIRECTLY_PHYSICALLY_INTERACTS_WITH,
     BIOLINK_ASSOCIATED_WITH,
     BIOLINK_CAUSES,
     BIOLINK_CORRELATED_WITH,
@@ -612,6 +614,59 @@ def test_chem_gene_ixns_response_to_substance_chemical_subject():
     assert association.predicate == BIOLINK_DECREASES_SENSITIVITY_TO
     assert association.subject == "MESH:C088349"
     assert association.object == "NCBIGene:3630"
+
+
+def test_chem_gene_ixns_binding_chemical_subject():
+    # CTD "affects^binding" -> directly_physically_interacts_with, no aspect/direction qualifier
+    record = {
+        "ChemicalName": "10-deacetylpaclitaxel",
+        "ChemicalID": "C08591",
+        "CasRN": "",
+        "GeneSymbol": "ABCB1",
+        "GeneID": "5243",
+        "GeneForms": "protein",
+        "Organism": "Homo sapiens",
+        "OrganismID": "9606",
+        "Interaction": "10-deacetylpaclitaxel binds to ABCB1 protein",
+        "InteractionActions": "affects^binding",
+        "PubMedIDs": "17171717",
+    }
+    entities = _run_chem_gene(record)
+    assert len(entities) == 3  # chemical, gene, association
+    # it is an interaction association, not an affects/causes or sensitivity edge
+    assert not any(isinstance(e, (ChemicalAffectsGeneAssociation, GeneAffectsChemicalAssociation)) for e in entities)
+    association = [e for e in entities if isinstance(e, ChemicalGeneInteractionAssociation)][0]
+    assert association.predicate == BIOLINK_DIRECTLY_PHYSICALLY_INTERACTS_WITH
+    assert association.subject == "MESH:C08591"
+    assert association.object == "NCBIGene:5243"
+    assert association.species_context_qualifier == "NCBITaxon:9606"
+    # binding asserts no effect, so no aspect or direction qualifier
+    assert association.object_aspect_qualifier is None
+    assert association.object_direction_qualifier is None
+    assert association.qualified_predicate is None
+    assert "PMID:17171717" in association.publications
+
+
+def test_chem_gene_ixns_binding_gene_subject():
+    # the gene can be named first ("<gene> protein binds to <chem>"); orientation follows the sentence
+    record = {
+        "ChemicalName": "1,2-oleoylphosphatidylcholine",
+        "ChemicalID": "C012587",
+        "CasRN": "",
+        "GeneSymbol": "LCAT",
+        "GeneID": "3931",
+        "GeneForms": "protein",
+        "Organism": "Homo sapiens",
+        "OrganismID": "9606",
+        "Interaction": "LCAT protein binds to 1,2-oleoylphosphatidylcholine",
+        "InteractionActions": "affects^binding",
+        "PubMedIDs": "18181818",
+    }
+    entities = _run_chem_gene(record)
+    association = [e for e in entities if isinstance(e, ChemicalGeneInteractionAssociation)][0]
+    assert association.predicate == BIOLINK_DIRECTLY_PHYSICALLY_INTERACTS_WITH
+    assert association.subject == "NCBIGene:3931"
+    assert association.object == "MESH:C012587"
 
 
 @pytest.fixture


### PR DESCRIPTION
After the phase 2 modeling review, the CTD RIG originally laid out plans to generate `biolink:directly_physically_interacts_with` edges from chemical-gene interaction data, but these interactions did not fit the pattern of other edges from that file and were never implemented.

This PR takes edges with the "affects^binding" interaction type and maps them to `biolink:directly_physically_interacts_with` edges. It updates the RIG and tests accordingly. 