### PR TITLE
Add source download date to pipeline metadata

### DIFF
--- a/src/translator_ingest/pipeline.py
+++ b/src/translator_ingest/pipeline.py
@@ -36,7 +36,11 @@ from translator_ingest.util.storage.local import (
     write_ingest_file,
 )
 from translator_ingest.util.validate_biolink_kgx import ValidationStatus, get_validation_status, validate_kgx, validate_kgx_nodes_only
-from translator_ingest.util.download_utils import record_download_metadata, substitute_version_in_download_yaml
+from translator_ingest.util.download_utils import (
+    get_recorded_download_date,
+    record_download_metadata,
+    substitute_version_in_download_yaml,
+)
 
 logger = get_logger(__name__)
 
@@ -618,6 +622,9 @@ def run_pipeline(source: str, transform_only: bool = False, overwrite: bool = Fa
 
     # Download the source data
     download(pipeline_metadata)
+    # Carry the recorded download timestamp (either new or from a previous download) into the
+    # pipeline metadata so it surfaces in the build and release metadata outputs.
+    pipeline_metadata.source_download_date = get_recorded_download_date(pipeline_metadata)
 
     # Transform the source data into KGX files if needed
     # Transform version is auto-computed as a content hash of the ingest's source files

--- a/src/translator_ingest/util/download_utils.py
+++ b/src/translator_ingest/util/download_utils.py
@@ -1,5 +1,6 @@
 """Utilities for handling download.yaml files and version substitution."""
 
+import json
 import tempfile
 import yaml
 from pathlib import Path
@@ -60,6 +61,28 @@ def record_download_metadata(
         f"Recorded download of {len(report.downloaded)} file(s) for {pipeline_metadata.source} "
         f"at {source_metadata_path}."
     )
+
+
+def get_recorded_download_date(pipeline_metadata: PipelineMetadata) -> Optional[str]:
+    """
+    Return the downloaded_at timestamp recorded in the source's source-metadata.json.
+
+    This reads back the timestamp persisted by record_download_metadata, which is only refreshed
+    when a real fetch occurred, so it reflects when the source data was genuinely last retrieved
+    (preserved across cache-hit reruns). Returns None if no source-metadata.json exists.
+
+    Args:
+        pipeline_metadata: Metadata identifying the source and version.
+
+    Returns:
+        The recorded ISO 8601 timestamp, or None if unavailable.
+    """
+    source_metadata_path = get_versioned_file_paths(
+        file_type=IngestFileType.SOURCE_METADATA_FILE, pipeline_metadata=pipeline_metadata
+    )
+    if not source_metadata_path.exists():
+        return None
+    return json.loads(source_metadata_path.read_text()).get("downloaded_at")
 
 
 def substitute_version_in_download_yaml(

--- a/src/translator_ingest/util/download_utils.py
+++ b/src/translator_ingest/util/download_utils.py
@@ -3,6 +3,7 @@
 import json
 import tempfile
 import yaml
+from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -69,7 +70,7 @@ def get_recorded_download_date(pipeline_metadata: PipelineMetadata) -> Optional[
 
     This reads back the timestamp persisted by record_download_metadata, which is only refreshed
     when a real fetch occurred, so it reflects when the source data was genuinely last retrieved
-    (preserved across cache-hit reruns). Returns None if no source-metadata.json exists.
+    (preserved across cache-hit reruns). Returns None if unavailable.
 
     Args:
         pipeline_metadata: Metadata identifying the source and version.
@@ -82,7 +83,10 @@ def get_recorded_download_date(pipeline_metadata: PipelineMetadata) -> Optional[
     )
     if not source_metadata_path.exists():
         return None
-    return json.loads(source_metadata_path.read_text()).get("downloaded_at")
+    try:
+        return json.loads(source_metadata_path.read_text()).get("downloaded_at")
+    except (JSONDecodeError, OSError):
+        return None
 
 
 def substitute_version_in_download_yaml(

--- a/src/translator_ingest/util/metadata.py
+++ b/src/translator_ingest/util/metadata.py
@@ -18,6 +18,8 @@ class PipelineMetadata:
     source: str
     # source_version: version of the source data itself, as determined by a get_latest_version() function
     source_version: str | None = None
+    # source_download_date: the timestamp (ISO 8601) the source data was actually fetched
+    source_download_date: str | None = None
     # transform_version: version of the translator-ingests ingest code used to generate KGX files from the source data
     transform_version: str | None = None
     # The following are normalization versions (babel_version, node_normalizer_version, normalization_code_version)
@@ -40,12 +42,12 @@ class PipelineMetadata:
     # build_version: a composite version representing all the dependencies which should be considered when determining
     # whether the pipeline needs to be run, or if an ingest was already fully completed
     build_version: str | None = None
-    # build_date: the date (ISO 8601, YYYY-MM-DD) the build was generated
+    # build_date: the timestamp (ISO 8601) the build was generated
     build_date: str | None = None
     # release_version: a version assigned to a completed ingest when it is released
     # (moved to the releases directory, compressed, and distribution metadata generated)
     release_version: str | None = None
-    # release_date: the date (ISO 8601, YYYY-MM-DD) the release was made
+    # release_date: the timestamp (ISO 8601) the release was made
     release_date: str | None = None
     # data: a URL pointing to the pipeline stage artifacts used to process an entire ingest
     data: str | None = None

--- a/tests/unit/test_download_utils.py
+++ b/tests/unit/test_download_utils.py
@@ -10,6 +10,7 @@ from tempfile import TemporaryDirectory
 from kghub_downloader.model import DownloadReport
 
 from translator_ingest.util.download_utils import (
+    get_recorded_download_date,
     record_download_metadata,
     substitute_version_in_download_yaml,
 )
@@ -191,6 +192,30 @@ def test_record_download_metadata_none_report_writes_nothing(source_data_dir):
     record_download_metadata(pipeline_metadata, None)
 
     assert not metadata_path.exists()
+
+
+def test_get_recorded_download_date_reads_back_recorded_timestamp(source_data_dir):
+    """get_recorded_download_date returns the downloaded_at that record_download_metadata persisted."""
+    pipeline_metadata, data_dir, metadata_path = source_data_dir
+    report = DownloadReport(downloaded=[data_dir / "fetched.tsv"])
+    record_download_metadata(pipeline_metadata, report)
+    recorded = json.loads(metadata_path.read_text())["downloaded_at"]
+    assert get_recorded_download_date(pipeline_metadata) == recorded
+
+
+def test_get_recorded_download_date_none_when_no_metadata(source_data_dir):
+    """With no source-metadata.json (e.g. a source without a download.yaml), the date is None."""
+    pipeline_metadata, _data_dir, _metadata_path = source_data_dir
+    assert get_recorded_download_date(pipeline_metadata) is None
+
+
+def test_source_download_date_surfaces_in_release_metadata():
+    """The source_download_date field flows into the build/release metadata output."""
+    pipeline_metadata = PipelineMetadata(
+        source="test_source", source_version="v1", source_download_date="2024-01-15T00:00:00Z"
+    )
+    release_metadata = pipeline_metadata.get_release_metadata()
+    assert release_metadata["source_download_date"] == "2024-01-15T00:00:00Z"
 
 
 def _fake_download(download_yaml_file: Path):


### PR DESCRIPTION
#455 implements a nice way to save source data download timestamps to a source-metadata file when the data is downloaded. However, that information never makes it's way to release metadata or graph metadata where most consumers might see it. This PR adds a source_download_date to PipelineMetadata and grabs the downloaded_at time from source-metadata to populate it. That way it is written to latest_build and latest_release metadata files any time a new build or release is made.

We probably want this in the final graph-metadata outputs as well, but some ORION work is ongoing that will affect the code surrounding the graph-metadata construction, so it will be cleaner to add it to the graph metadata inside of ORION and implement it here after that.