### PR TITLE
Fix GOA unknown predicate: use biolink:actively_involved_in

### DIFF
--- a/src/translator_ingest/ingests/goa/README.md
+++ b/src/translator_ingest/ingests/goa/README.md
@@ -46,9 +46,9 @@ GO aspect is mapped to the most specific Biolink class:
 Rationale: Using specific GO-domain classes improves downstream reasoning and alignment with Biolink’s semantic hierarchy.
 
 ### Predicate Selection
-1. Prefer qualifier-based predicates when present, covering standard and upstream-effect relations (e.g., enables, contributes_to, participates_in, located_in, is_active_in, colocalizes_with, acts_upstream_of, acts_upstream_of_or_within, and their positive/negative effect variants).
+1. Prefer qualifier-based predicates when present, covering standard and upstream-effect relations (e.g., enables, contributes_to, actively_involved_in, located_in, is_active_in, colocalizes_with, acts_upstream_of, acts_upstream_of_or_within, and their positive/negative effect variants).
 2. If a qualifier is absent or unrecognized, fall back to aspect-based defaults:
-   - P → participates_in
+   - P → actively_involved_in
    - F → enables
    - C → located_in
 

--- a/src/translator_ingest/ingests/goa/goa.py
+++ b/src/translator_ingest/ingests/goa/goa.py
@@ -82,7 +82,7 @@ QUALIFIER_TO_PREDICATE = {
     "enables": "biolink:enables",
     "located_in": "biolink:located_in",
     "part_of": "biolink:part_of",
-    "involved_in": "biolink:involved_in",
+    "involved_in": "biolink:actively_involved_in",
     "contributes_to": "biolink:contributes_to",
     "colocalizes_with": "biolink:colocalizes_with",
     "is_active_in": "biolink:active_in",
@@ -98,7 +98,7 @@ QUALIFIER_TO_PREDICATE = {
 
 # Fallback mapping for aspect-based predicates (used when the qualifier is not recognized)
 ASPECT_TO_PREDICATE = {
-    "P": "biolink:involved_in",  # Biological Process
+    "P": "biolink:actively_involved_in",  # Biological Process
     "F": "biolink:enables",  # Molecular Function
     "C": "biolink:located_in",  # Cellular Component
 }

--- a/src/translator_ingest/ingests/goa/goa_rig.yaml
+++ b/src/translator_ingest/ingests/goa/goa_rig.yaml
@@ -129,7 +129,7 @@ target_info:
         - biolink:MacromolecularComplex
         - biolink:RNAProduct
       predicates:
-        - biolink:involved_in
+        - biolink:actively_involved_in
       object_categories:
         - biolink:BiologicalProcess
       knowledge_level:
@@ -145,7 +145,7 @@ target_info:
         - negated
         - has_evidence_of_type
         - publications
-      ui_explanation: "A GO Annotation uses 'involved_in' predicate when a gene product's molecular function plays an integral role in the reported biological process."
+      ui_explanation: "A GO Annotation uses the 'actively_involved_in' predicate when a gene product's molecular function plays an integral role in the reported biological process."
       additional_notes:
         - "varies, depending on mappings from GO evidence codes"
 
@@ -276,18 +276,15 @@ target_info:
     - issue: "Predicate normalization changes some edge types"
       description: |
         After normalization, predicates are transformed as follows:
-        - involved_in → related_to (generalized, no direct Biolink predicate mapping in current normalization output)
         - part_of → has_part (inverted, subject/object swap)
         - active_in → active_in (retained after predicate correction)
         This is documented in predicate_map.json output.
       resolution: "Accepted. The ingest outputs the semantically correct predicates; normalization adjusts for Biolink conventions."
     # Validation produces warnings for domain/range that we accept
-    - issue: "Domain/range validation warnings for related_to and enables"
+    - issue: "Domain/range validation warnings for enables"
       description: |
-        Validation reports ~27k sampled warnings about domain/range constraints:
-        - related_to is broad and can trigger low-specificity domain/range warnings after normalization
+        Validation reports sampled warnings about domain/range constraints:
         - enables expects domain 'physical entity' but subjects are Gene/Protein
-        These occur primarily because normalization maps involved_in edges to related_to.
       resolution: "Accepted as warnings. Edges pass validation; warnings reflect Biolink model strictness."
     # Some GO BP terms become Pathway after normalization
     - issue: "GO Biological Process terms re-categorized as Pathway"

--- a/tests/unit/ingests/goa/test_goa.py
+++ b/tests/unit/ingests/goa/test_goa.py
@@ -16,6 +16,7 @@ from translator_ingest.ingests.goa.goa import (
     QUALIFIER_TO_PREDICATE,
     get_supporting_data_sources,
 )
+from translator_ingest.util.biolink import get_biolink_model_toolkit
 
 
 GOA_RIG_PATH = (
@@ -36,6 +37,23 @@ def _get_goa_rig_predicates() -> set[str]:
     return {predicate for edge_type in edge_type_info for predicate in edge_type["predicates"]}
 
 
+def _get_valid_predicate_curies() -> set[str]:
+    """Return every canonical predicate CURIE (slot_uri) in the pinned Biolink Model.
+
+    Mirrors ``BiolinkValidationPlugin._get_valid_predicates``: predicates are the
+    ``slot_uri`` values of the descendants of ``related to``. A predicate string is
+    only valid on an emitted edge if it matches one of these URIs; alias names such
+    as ``involved in`` resolve via ``get_element`` but never appear as a ``slot_uri``.
+    """
+    toolkit = get_biolink_model_toolkit()
+    valid_uris: set[str] = set()
+    for name in toolkit.get_descendants("related to", reflexive=True, mixin=True):
+        element = toolkit.get_element(name)
+        if element is not None and getattr(element, "slot_uri", None):
+            valid_uris.add(element.slot_uri)
+    return valid_uris
+
+
 def test_goa_predicates_in_code_match_rig() -> None:
     """Ensure GOA transform predicates align with GOA RIG edge predicate definitions."""
     rig_predicates = _get_goa_rig_predicates()
@@ -44,9 +62,27 @@ def test_goa_predicates_in_code_match_rig() -> None:
 
 
 @pytest.mark.parametrize(
+    "predicate",
+    sorted(
+        set(QUALIFIER_TO_PREDICATE.values())
+        | set(ASPECT_TO_PREDICATE.values())
+        | _get_goa_rig_predicates()
+    ),
+)
+def test_goa_predicates_exist_in_biolink_model(predicate: str) -> None:
+    """Every GOA predicate must be a real Biolink slot_uri, not just an alias.
+
+    This is the check that would have caught issue #463: ``biolink:involved_in``
+    is only an alias of ``biolink:actively_involved_in`` and has no slot_uri, so
+    it is rejected here while the canonical predicate passes.
+    """
+    assert predicate in _get_valid_predicate_curies()
+
+
+@pytest.mark.parametrize(
     ("qualifier", "expected_predicate"),
     [
-        ("involved_in", "biolink:involved_in"),
+        ("involved_in", "biolink:actively_involved_in"),
         ("enables", "biolink:enables"),
         ("located_in", "biolink:located_in"),
         ("is_active_in", "biolink:active_in"),
@@ -60,7 +96,7 @@ def test_goa_qualifier_mapping(qualifier: str, expected_predicate: str) -> None:
 
 def test_goa_aspect_fallback_for_biological_process() -> None:
     """Ensure biological process fallback predicate matches GOA RIG."""
-    assert ASPECT_TO_PREDICATE["P"] == "biolink:involved_in"
+    assert ASPECT_TO_PREDICATE["P"] == "biolink:actively_involved_in"
 
 
 @pytest.mark.parametrize(
@@ -400,7 +436,7 @@ EDGE_FIXTURES = [
         "params": {
             "id": "1b86df80-3be7-4160-a5f7-ff5fee6ab875",
             "subject": "NCBIGene:7534",
-            "predicate": "biolink:involved_in",
+            "predicate": "biolink:actively_involved_in",
             "object": "GO:0001525",
             "knowledge_level": KnowledgeLevelEnum.prediction,
             "agent_type": AgentTypeEnum.automated_agent,
@@ -412,7 +448,7 @@ EDGE_FIXTURES = [
         "params": {
             "id": "3a899606-d1ed-488e-b1ae-14f1c8a9bbd9",
             "subject": "NCBIGene:29082",
-            "predicate": "biolink:involved_in",
+            "predicate": "biolink:actively_involved_in",
             "object": "GO:0016236",
             "knowledge_level": KnowledgeLevelEnum.knowledge_assertion,
             "agent_type": AgentTypeEnum.manual_agent,
@@ -424,7 +460,7 @@ EDGE_FIXTURES = [
         "params": {
             "id": "4b0ddb2c-04b4-4c6e-899b-96b16e64efdb",
             "subject": "UniProtKB:A0M8Q6",
-            "predicate": "biolink:involved_in",
+            "predicate": "biolink:actively_involved_in",
             "object": "GO:0002250",
             "knowledge_level": KnowledgeLevelEnum.prediction,
             "agent_type": AgentTypeEnum.manual_agent,
@@ -436,7 +472,7 @@ EDGE_FIXTURES = [
         "params": {
             "id": "28182f19-9776-4538-a27c-36460c4a4d38",
             "subject": "NCBIGene:7471",
-            "predicate": "biolink:involved_in",
+            "predicate": "biolink:actively_involved_in",
             "object": "GO:0045165",
             "knowledge_level": KnowledgeLevelEnum.prediction,
             "agent_type": AgentTypeEnum.manual_validation_of_automated_agent,
@@ -448,7 +484,7 @@ EDGE_FIXTURES = [
         "params": {
             "id": "0553359b-4a11-5817-b2e2-5ef1801d0ce7",
             "subject": "NCBIGene:102553861",
-            "predicate": "biolink:involved_in",
+            "predicate": "biolink:actively_involved_in",
             "object": "GO:0140507",
             "knowledge_level": KnowledgeLevelEnum.prediction,
             "agent_type": AgentTypeEnum.manual_validation_of_automated_agent,
@@ -460,7 +496,7 @@ EDGE_FIXTURES = [
         "params": {
             "id": "bfa31a13-f3a2-4f41-b3ed-6712d9327d63",
             "subject": "NCBIGene:643641",
-            "predicate": "biolink:involved_in",
+            "predicate": "biolink:actively_involved_in",
             "object": "GO:0008150",
             "knowledge_level": KnowledgeLevelEnum.not_provided,
             "agent_type": AgentTypeEnum.not_provided,
@@ -916,7 +952,7 @@ EDGE_FIXTURES = [
         "params": {
             "id": "000013d2-281c-5bb0-a0d7-619f4dcf6d93",
             "subject": "NCBIGene:24585",
-            "predicate": "biolink:involved_in",
+            "predicate": "biolink:actively_involved_in",
             "object": "GO:0006942",
             "knowledge_level": KnowledgeLevelEnum.prediction,
             "agent_type": AgentTypeEnum.automated_agent,
@@ -928,7 +964,7 @@ EDGE_FIXTURES = [
         "params": {
             "id": "fe9de6b5-bb24-488b-a880-1eac92c9d80b",
             "subject": "NCBIGene:66983",
-            "predicate": "biolink:involved_in",
+            "predicate": "biolink:actively_involved_in",
             "object": "GO:0001546",
             "knowledge_level": KnowledgeLevelEnum.knowledge_assertion,
             "agent_type": AgentTypeEnum.manual_agent,
@@ -940,7 +976,7 @@ EDGE_FIXTURES = [
         "params": {
             "id": "9ea07fc8-b38c-4e5a-9c21-3e2ec2679c0f",
             "subject": "NCBIGene:75613",
-            "predicate": "biolink:involved_in",
+            "predicate": "biolink:actively_involved_in",
             "object": "GO:0060261",
             "knowledge_level": KnowledgeLevelEnum.prediction,
             "agent_type": AgentTypeEnum.manual_agent,
@@ -952,7 +988,7 @@ EDGE_FIXTURES = [
         "params": {
             "id": "bea22260-7d99-4246-ae09-0a1ce021fec7",
             "subject": "NCBIGene:405219",
-            "predicate": "biolink:involved_in",
+            "predicate": "biolink:actively_involved_in",
             "object": "GO:0050911",
             "knowledge_level": KnowledgeLevelEnum.prediction,
             "agent_type": AgentTypeEnum.manual_validation_of_automated_agent,
@@ -964,7 +1000,7 @@ EDGE_FIXTURES = [
         "params": {
             "id": "0966d200-2c53-40ac-9047-d3734b29f49a",
             "subject": "NCBIGene:102637107",
-            "predicate": "biolink:involved_in",
+            "predicate": "biolink:actively_involved_in",
             "object": "GO:0008150",
             "knowledge_level": KnowledgeLevelEnum.not_provided,
             "agent_type": AgentTypeEnum.not_provided,


### PR DESCRIPTION
Fixes #463

`biolink:involved_in` is not a real Biolink predicate. No slot in `biolink-model` 4.4.2 (the pinned version) has `slot_uri` equal to `biolink:involved_in`. It only exists as an alias of `actively involved in`, so `bmt` `get_element` resolves it to `biolink:actively_involved_in`. The edge carries the `slot_uri`, not the alias, so GOA was emitting a predicate that does not exist. The correct one is `biolink:actively_involved_in`. It is canonical and valid for the GOA subject and object types.

How it happened: the first GOA RIG was a markdown table using the bare relation name `involved_in`, which is the correct GO qualifier name. When the RIGs were converted to yaml in Oct 2025 the relation names got a `biolink:` prefix. That works for most GOA predicates because GO and Biolink use the same name. `involved_in` is the one that does not. Biolink calls it `actively_involved_in` and keeps `involved_in` only as an alias, so the prefix produced a CURIE that does not exist. My code first emitted `biolink:participates_in`, which is a real slot. In #288 I changed the code to match the yaml RIG, and that is when `biolink:involved_in` started landing on edges.

Changes, GOA only:

- `goa.py`: map the `involved_in` qualifier and the P aspect fallback to `biolink:actively_involved_in`
- `goa_rig.yaml`: fix the declared predicate and `ui_explanation`, and drop the `known_issues` note that recorded the `involved_in` to `related_to` normalization as accepted behavior, since that was the symptom of the bug
- `README.md`: fix the stale P aspect fallback
- `test_goa.py`: update the pinned expected predicates and add a `bmt` test that resolves every declared GOA predicate to a real `slot_uri`, so this class of bug fails the tests next time

Tests: `pytest tests/unit/ingests/goa/test_goa.py` passes (109). `ruff` clean.
