### PR TITLE
PathBank RIG review & completion (draft, #433)

### DIFF
--- a/src/translator_ingest/ingests/pathbank/pathbank_rig.yaml
+++ b/src/translator_ingest/ingests/pathbank/pathbank_rig.yaml
@@ -3,27 +3,56 @@ name: PathBank Reference Ingest Guide (RIG)
 source_info:
   infores_id: infores:pathbank
   name: PathBank
-  description: "PathBank is a comprehensive, visually rich pathway database (>110k pathways) providing machine-readable exports (PWML, BioPAX, SBML, SBGN) and CSV summaries for pathway metadata and links."
+  description: >-
+    PathBank is a comprehensive, visually rich pathway database from the Wishart Lab (University of
+    Alberta), designed as a companion to the Small Molecule Pathway Database (SMPDB). It provides
+    interactive, machine-readable pathway diagrams spanning metabolic, signaling, disease, drug-action,
+    drug-metabolism, physiological, and protein pathways across model organisms (with a strong emphasis on
+    human). Each pathway describes participating small molecules, proteins, protein complexes, nucleic
+    acids, reactions, and their subcellular/tissue localization. PathBank distributes machine-readable
+    exports in several formats (PWML, BioPAX, SBML, SBGN) plus CSV summaries of pathway metadata, as well
+    as image (SVG/PNG) and sequence (FASTA/SDF) files. This ingest uses the master pathways CSV and the
+    per-pathway PWML (XML) archive.
   citations:
-    - "PathBank NAR article: https://doi.org/10.1093/nar/gkz861"
+    - "Wishart DS, et al. PathBank: a comprehensive pathway database for model organisms. Nucleic Acids Res. 2020 Jan 8;48(D1):D470-D478. https://doi.org/10.1093/nar/gkz861"
     - "Downloads page: https://pathbank.org/downloads"
   terms_of_use_info:
     terms_of_use_url: "https://pathbank.org/about"
-    license_name: "See PathBank About/Downloads for reuse and citation guidance"
+    terms_of_use_description: >-
+      PathBank does not publish a formal open-source license alongside its downloads; the About and
+      Downloads pages provide reuse and citation guidance. TODO: owner to confirm the applicable license
+      / terms of use before publication.
   data_access_locations:
     - "All downloads: https://pathbank.org/downloads"
   data_provision_mechanisms:
     - file_download
   data_formats:
     - csv
-    - other  # conformance: was 'pwml'
-  data_versioning_and_releases: "Treat each pull as a dated snapshot; downloads list 'Generated On' timestamps and large per-format archives."
+    - xml  # PWML is an XML-based markup format, parsed here with xmltodict
+  data_versioning_and_releases: >-
+    PathBank does not publish an explicit, regularly-scheduled release version. Treat each pull as a dated
+    snapshot; the downloads page lists 'Generated On' timestamps and large per-format archives. The ingest
+    derives its version string from the most recent file modification date of the pathways CSV and PWML
+    archives (see get_latest_version in pathbank.py).
+  source_status: unknown
+  additional_notes:
+    - >-
+      TODO (owner decision): source_status is set to 'unknown' pending confirmation of PathBank's current
+      maintenance/update cadence. PathBank remains online and serves downloadable archives with
+      'Generated On' timestamps, but no regular release schedule is published and the primary publication
+      dates to 2020. Owner (@bazarkua) should confirm whether 'maintained_as_needed_updates' or another
+      value is more accurate.
 
 ingest_info:
   ingest_categories:
     - primary_knowledge_provider
-  utility: "Comprehensive pathway membership and mechanistic process data (reactions, transports, interactions) for Translator reasoning and pathway-centric analytics."
-  scope: "This ingest uses only two inputs: the master pathways CSV for biolink:Pathway nodes and the PWML archive for entities, processes, and edges. Other formats available from PathBank (BioPAX, SBML, SBGN, RXN, SVG, PNG, FASTA, SDF) are not currently used but may be considered for future enrichment."
+  utility: >-
+    Comprehensive pathway membership and mechanistic process data (reactions, transports, interactions,
+    complex composition, localization) for Translator reasoning and pathway-centric analytics.
+  scope: >-
+    This ingest uses only two inputs: the master pathways CSV for biolink:Pathway nodes and the PWML
+    archive for entities, processes, and edges. Other formats available from PathBank (BioPAX, SBML, SBGN,
+    RXN, SVG, PNG, FASTA, SDF) are not currently used but may be considered for future enrichment.
 
   relevant_files:
     - file_name: "pathbank_all_pathways.csv.zip"
@@ -31,28 +60,28 @@ ingest_info:
       description: "Master CSV with pathway subjects and descriptions; used to build Pathway nodes with IDs, names, descriptions, and species metadata."
     - file_name: "pathbank_all_pwml.zip"
       location: "https://pathbank.org/downloads"
-      description: "Per-pathway PWML files for detailed composition and connectivity (entities, processes, participants, localization, complexes)."
+      description: "Per-pathway PWML (XML) files for detailed composition and connectivity (entities, processes, participants, localization, complexes)."
 
   included_content:
     - file_name: "pathbank_all_pathways.csv.zip"
-      included_records: "All pathway rows extracted to pathbank_pathways.csv"
-      fields_used: "SMPDB ID, PW ID, Name, Description"
+      included_records: "All pathway rows extracted to pathbank_pathways.csv (rows with at least one of SMPDB ID or PW ID)."
+      fields_used: "SMPDB ID, PW ID, Name, Subject, Description"
     - file_name: "pathbank_all_pwml.zip"
-      included_records: "All PWML pathway files"
-      fields_used: "entities (compounds, proteins, complexes, nucleic acids), processes (reactions, transports, interactions), participants (inputs/outputs), enzymes/transporters, localization (compartments/tissues)"
+      included_records: "All PWML pathway files (PW*.pwml)."
+      fields_used: "entities (compounds, proteins, complexes, nucleic acids, element collections, bounds), processes (reactions, transports, interactions), participants (inputs/outputs), enzymes/transporters, localization (subcellular compartments/tissues)"
 
-  # Note: filtered_content is omitted because all records from the included files (pathbank_pathways.csv and PWML files) are used without filtering.
+  # Note: filtered_content is omitted because all records from the included files
+  # (pathbank_pathways.csv and PWML files) are used without record-level filtering.
 
   future_considerations:
     - category: edge_property_content
-      consideration: "Edge properties such as stoichiometry and participant_role - may be added in future if needed and if supported by Biolink Model"
+      consideration: "Edge properties such as stoichiometry and participant_role may be added in future if needed and if supported by Biolink Model."
     - category: edge_content
-      consideration: "Additional file formats available from PathBank (BioPAX, SBML, SBGN, RXN, SVG, PNG, FASTA, SDF) may be considered for future enrichment to provide additional pathway representations and visualizations"
+      consideration: "Additional file formats available from PathBank (BioPAX, SBML, SBGN, RXN, SVG, PNG, FASTA, SDF) may be considered for future enrichment to provide additional pathway representations and visualizations."
     - category: edge_content
-      consideration: "Additional interaction type mappings may be added as more PathBank interaction types are discovered and validated against Biolink Model predicates"
-    
+      consideration: "Additional interaction type mappings may be added as more PathBank interaction types are discovered and validated against Biolink Model predicates."
+
 target_info:
-  infores_id: infores:translator-pathbank-kgx
   edge_type_info:
     - subject_categories:
         - biolink:Pathway
@@ -71,11 +100,13 @@ target_info:
         - manual_agent
       primary_knowledge_sources:
         - infores:pathbank
-      ui_explanation: "Pathway has the specified entity as a participant (from PWML membership and context)."
+      ui_explanation: "PathBank asserts that the named entity is a participant in this pathway. The edge is derived from the entity's membership in the pathway's PWML file (compounds, proteins, complexes, nucleic acids, element collections, bounds, and reactions all yield has_participant edges from the pathway to the entity)."
       source_files:
         - pathbank_all_pwml.zip
         - pathbank_all_pathways.csv.zip
-        
+      additional_notes:
+        - "biolink:has_participant nominally expects an 'occurrent' object; PathBank participants are molecular entities and reactions. See known-issue notes in target_info.additional_notes."
+
     - subject_categories:
         - biolink:MolecularActivity
       predicates:
@@ -91,11 +122,11 @@ target_info:
       agent_type:
         - manual_agent
       primary_knowledge_sources:
-        - infores:pathbank        
-      ui_explanation: "Reaction (molecular activity) consumes specified inputs (reactants) extracted from PWML participants."
+        - infores:pathbank
+      ui_explanation: "A PathBank reaction (represented as a MolecularActivity) consumes the named inputs (reactants). The edge is extracted from the reaction's left elements in the PWML file."
       source_files:
         - pathbank_all_pwml.zip
-        
+
     - subject_categories:
         - biolink:MolecularActivity
       predicates:
@@ -111,11 +142,11 @@ target_info:
       agent_type:
         - manual_agent
       primary_knowledge_sources:
-        - infores:pathbank        
-      ui_explanation: "Reaction (molecular activity) produces specified outputs (products) as defined in PWML."
+        - infores:pathbank
+      ui_explanation: "A PathBank reaction (represented as a MolecularActivity) produces the named outputs (products). The edge is extracted from the reaction's right elements in the PWML file."
       source_files:
         - pathbank_all_pwml.zip
-        
+
     - subject_categories:
         - biolink:MacromolecularComplex
       predicates:
@@ -127,30 +158,38 @@ target_info:
       agent_type:
         - manual_agent
       primary_knowledge_sources:
-        - infores:pathbank        
-      ui_explanation: "Enzyme or protein complex catalyzes the specified reaction (molecular activity) as identified in PWML."
+        - infores:pathbank
+      ui_explanation: "An enzyme (modeled as a protein complex / MacromolecularComplex) catalyzes the named reaction (MolecularActivity), as identified from the reaction's enzyme references in the PWML file."
       source_files:
         - pathbank_all_pwml.zip
-        
+
     - subject_categories:
         - biolink:MacromolecularComplex
+        - biolink:ChemicalEntity
       predicates:
         - biolink:has_part
       object_categories:
         - biolink:Protein
+        - biolink:SmallMolecule
+        - biolink:NucleicAcidEntity
+        - biolink:MacromolecularComplex
+        - biolink:ChemicalEntity
       knowledge_level:
         - knowledge_assertion
       agent_type:
         - manual_agent
       primary_knowledge_sources:
-        - infores:pathbank        
-      ui_explanation: "Complex contains specified proteins per PWML composition."
+        - infores:pathbank
+      ui_explanation: "Compositional membership: a protein complex has member proteins, and a PathBank 'bound' aggregate (modeled as a ChemicalEntity) has member elements. Both are represented with biolink:has_part."
       source_files:
         - pathbank_all_pwml.zip
-        
+      additional_notes:
+        - "Two code paths emit has_part. Protein complexes link to their member proteins (MacromolecularComplex has_part Protein). PathBank 'bound' ChemicalEntity nodes link to their member elements, which may be compounds (SmallMolecule), proteins, nucleic acids, protein complexes (MacromolecularComplex), element collections, or other bounds (ChemicalEntity)."
+
     - subject_categories:
         - biolink:Protein
         - biolink:MacromolecularComplex
+        - biolink:NucleicAcidEntity
       predicates:
         - biolink:regulates
       qualifiers:
@@ -166,6 +205,7 @@ target_info:
       object_categories:
         - biolink:Protein
         - biolink:MacromolecularComplex
+        - biolink:NucleicAcidEntity
         - biolink:SmallMolecule
         - biolink:ChemicalEntity
       knowledge_level:
@@ -173,10 +213,12 @@ target_info:
       agent_type:
         - manual_agent
       primary_knowledge_sources:
-        - infores:pathbank        
-      ui_explanation: "Directional regulation edges derived from PWML interaction types. Qualifiers specify affected aspect and direction when available."
+        - infores:pathbank
+      ui_explanation: "Directional regulation edges derived from PathBank PWML interaction types where the regulator (subject) is a biological entity (protein, protein complex, or nucleic acid). Activation/induction/promotion maps to an upregulated direction and inhibition/repression to a downregulated direction, with an activity_or_abundance object aspect."
       source_files:
         - pathbank_all_pwml.zip
+      additional_notes:
+        - "Qualifiers are applied only when the interaction maps to a specialized regulation association class (e.g. GeneRegulatesGeneAssociation); when no such class applies, a generic biolink:Association without qualifiers is emitted. The object_aspect_qualifier value used by the transform is 'activity_or_abundance'."
 
     - subject_categories:
         - biolink:SmallMolecule
@@ -196,6 +238,7 @@ target_info:
       object_categories:
         - biolink:Protein
         - biolink:MacromolecularComplex
+        - biolink:NucleicAcidEntity
         - biolink:SmallMolecule
         - biolink:ChemicalEntity
       knowledge_level:
@@ -203,14 +246,17 @@ target_info:
       agent_type:
         - manual_agent
       primary_knowledge_sources:
-        - infores:pathbank        
-      ui_explanation: "Directional chemical effect edges derived from PWML interaction types. Qualifiers specify affected aspect and direction when available."
+        - infores:pathbank
+      ui_explanation: "Directional chemical effect edges derived from PathBank PWML interaction types where the actor (subject) is a chemical entity. Activation/induction/promotion maps to an upregulated direction and inhibition/repression to a downregulated direction, with an activity_or_abundance object aspect."
       source_files:
         - pathbank_all_pwml.zip
-        
+      additional_notes:
+        - "Qualifiers are applied only when the interaction maps to a specialized association class (e.g. ChemicalAffectsBiologicalEntityAssociation); otherwise a generic biolink:Association without qualifiers is emitted. The object_aspect_qualifier value used by the transform is 'activity_or_abundance'."
+
     - subject_categories:
         - biolink:Protein
         - biolink:MacromolecularComplex
+        - biolink:NucleicAcidEntity
         - biolink:SmallMolecule
         - biolink:ChemicalEntity
       predicates:
@@ -218,6 +264,7 @@ target_info:
       object_categories:
         - biolink:Protein
         - biolink:MacromolecularComplex
+        - biolink:NucleicAcidEntity
         - biolink:SmallMolecule
         - biolink:ChemicalEntity
       knowledge_level:
@@ -225,14 +272,15 @@ target_info:
       agent_type:
         - manual_agent
       primary_knowledge_sources:
-        - infores:pathbank        
-      ui_explanation: "Physical interactions derived from PWML interaction types such as binding or complex formation."
+        - infores:pathbank
+      ui_explanation: "Physical interaction edges derived from PathBank PWML interaction types that indicate binding, physical association, or complex formation."
       source_files:
         - pathbank_all_pwml.zip
-        
+
     - subject_categories:
         - biolink:Protein
         - biolink:MacromolecularComplex
+        - biolink:NucleicAcidEntity
         - biolink:SmallMolecule
         - biolink:ChemicalEntity
       predicates:
@@ -240,6 +288,7 @@ target_info:
       object_categories:
         - biolink:Protein
         - biolink:MacromolecularComplex
+        - biolink:NucleicAcidEntity
         - biolink:SmallMolecule
         - biolink:ChemicalEntity
       knowledge_level:
@@ -247,11 +296,11 @@ target_info:
       agent_type:
         - manual_agent
       primary_knowledge_sources:
-        - infores:pathbank        
-      ui_explanation: "Fallback interaction predicate for PWML interaction types that cannot be mapped more specifically."
+        - infores:pathbank
+      ui_explanation: "Fallback interaction predicate for PathBank PWML interaction types that cannot be mapped to a more specific regulation, effect, or physical-interaction predicate."
       source_files:
         - pathbank_all_pwml.zip
-        
+
     - subject_categories:
         - biolink:Pathway
       predicates:
@@ -264,11 +313,13 @@ target_info:
       agent_type:
         - manual_agent
       primary_knowledge_sources:
-        - infores:pathbank        
-      ui_explanation: "Pathway localization to subcellular compartments (GO terms) and tissues (BTO terms) as specified in PWML data."
+        - infores:pathbank
+      ui_explanation: "Pathway localization to subcellular compartments (GO cellular component terms) and tissues (BTO terms), as specified in the PWML subcellular-location and tissue data."
       source_files:
         - pathbank_all_pwml.zip
         - pathbank_all_pathways.csv.zip
+      additional_notes:
+        - "One GO term (GO:0043165), which normalizes to biolink:BiologicalProcess rather than CellularComponent/AnatomicalEntity, is excluded in code (EXCLUDED_OCCURS_IN_GO_TERMS) to keep occurs_in object categories within the expected set."
 
   node_type_info:
     - node_category: biolink:Pathway
@@ -323,48 +374,32 @@ target_info:
       additional_notes:
         - "Tissues and anatomical entities extracted from PWML data. Biolink class reference: https://biolink.github.io/biolink-model/AnatomicalEntity/"
 
-  future_considerations:  # (optional, multivalued, range = FutureModelingConsiderations) Notes on possible changes/additions to modeling in future iteration of the ingest
+  future_considerations:
     - category: spoq_pattern
-      consideration: "MolecularActivity nodes represent reactions.  Current modeling creates separate edges describing inputs and outputs for these reactions. This is supported by Biolink, but longer term consider is this the most useful pattern for Translator? Could we model direct 'derived from/into' edges between inputs and outputs and hang the reaction id as a qualifier? A redesign to direct input-output edges with reaction qualifiers would need an agreed KG modeling pattern across sources."
-# Manual QA 1: Known issues identified during validation
-known_issues:
-  # Most PathBank edges involve MolecularActivity and MacromolecularComplex nodes
-  # that use internal PathBank IDs. NodeNorm doesn't recognize these, so ~88% of
-  # edges get dropped during normalization.
-  - issue: "Large normalization drop (~88% of edges)"
-    description: |
-      PathBank internal IDs (Reaction_, ProteinComplex_, some Compound_) are not
-      recognized by NodeNorm. The ingest correctly produces 12.8M edges, but 11.3M
-      are filtered out because subject or object nodes fail normalization.
-    resolution: "Long-term: Request NodeNorm support for PathBank IDs or map reactions to EC numbers."
+      consideration: "MolecularActivity nodes represent reactions. Current modeling creates separate edges describing inputs and outputs for these reactions. This is supported by Biolink, but longer term consider whether this is the most useful pattern for Translator. Could we model direct 'derived from/into' edges between inputs and outputs and hang the reaction id as a qualifier? A redesign to direct input-output edges with reaction qualifiers would need an agreed KG modeling pattern across sources."
+    - category: predicates
+      consideration: "Interaction-derived predicates (regulates, affects, physically_interacts_with, interacts_with) are assigned via keyword matching on PathBank interaction-type strings (see interaction_mapping.py). Review and extend these mappings as additional PathBank interaction types are validated against Biolink."
 
-  # The RIG documents predicates like has_input, has_output, catalyzes, has_part,
-  # regulates, physically_interacts_with - but these only appear on edges involving
-  # MolecularActivity or MacromolecularComplex nodes that fail normalization.
-  - issue: "Missing predicates in normalized output"
-    description: |
-      Predicates like has_input, has_output, catalyzes, has_part, regulates, and
-      physically_interacts_with are correctly emitted by the ingest but only appear
-      on edges involving MolecularActivity/MacromolecularComplex nodes. These nodes
-      fail NodeNorm, so the edges are dropped.
-    resolution: "Long-term: Depends on fixing normalization drop. Final output only has has_participant, occurs_in, interacts_with."
-
-  # Biolink has_participant expects an "occurrent" (process/event) as object,
-  # but PathBank pathways correctly have chemicals and proteins as participants.
-  - issue: "Validation warnings for has_participant range"
-    description: |
-      66,656 validation warnings occur because biolink:has_participant expects
-      range 'occurrent' but objects are SmallMolecule, Protein, Drug, etc.
-      The data is semantically correct - pathways do have these participants.
-    resolution: "Accepted as warnings. The edges are valid pathway membership assertions."
-
-  # One GO term (GO:0043165) normalized to BiologicalProcess instead of CellularComponent
-  - issue: "occurs_in edge to BiologicalProcess"
-    description: |
-      1 edge has a BiologicalProcess object (from GO term normalization) instead
-      of the expected CellularComponent or AnatomicalEntity. This happens when
-      a GO cellular component term gets normalized to a process category.
-    resolution: "Accepted as edge case. The edge is valid but doesn't match RIG's expected object categories."
+  additional_notes:
+    - >-
+      Known issue - large normalization drop (~88% of edges): PathBank internal IDs (Reaction_,
+      ProteinComplex_, some Compound_) are not recognized by NodeNorm. The ingest produces ~12.8M edges,
+      but ~11.3M are filtered out because subject or object nodes fail normalization. Long-term
+      resolution: request NodeNorm support for PathBank IDs, or map reactions to EC numbers.
+    - >-
+      Known issue - predicates missing from normalized output: has_input, has_output, catalyzes, has_part,
+      regulates, and physically_interacts_with are emitted by the ingest but appear only on edges
+      involving MolecularActivity / MacromolecularComplex nodes that fail NodeNorm, so those edges are
+      dropped. After normalization the output retains mainly has_participant, occurs_in, and
+      interacts_with. This depends on fixing the normalization drop above.
+    - >-
+      Known issue - has_participant range warnings: ~66,656 validation warnings occur because
+      biolink:has_participant expects an 'occurrent' range but objects are SmallMolecule, Protein, etc.
+      The data is semantically correct (pathways do have these participants); accepted as warnings.
+    - >-
+      Known issue - occurs_in to BiologicalProcess: GO:0043165 normalizes to biolink:BiologicalProcess
+      rather than CellularComponent/AnatomicalEntity. It is now excluded in code
+      (EXCLUDED_OCCURS_IN_GO_TERMS) so occurs_in objects stay within the expected categories.
 
 provenance_info:
   contributions:

--- a/src/translator_ingest/ingests/pathbank/pathbank_rig.yaml
+++ b/src/translator_ingest/ingests/pathbank/pathbank_rig.yaml
@@ -15,13 +15,18 @@ source_info:
     per-pathway PWML (XML) archive.
   citations:
     - "Wishart DS, et al. PathBank: a comprehensive pathway database for model organisms. Nucleic Acids Res. 2020 Jan 8;48(D1):D470-D478. https://doi.org/10.1093/nar/gkz861"
+    - "Wishart DS, et al. PathBank 2.0 - the pathway database for model organism metabolomics. Nucleic Acids Res. 2024 Jan 5;52(D1):D654-D662. https://doi.org/10.1093/nar/gkad1041"
     - "Downloads page: https://pathbank.org/downloads"
   terms_of_use_info:
     terms_of_use_url: "https://pathbank.org/about"
     terms_of_use_description: >-
-      PathBank does not publish a formal open-source license alongside its downloads; the About and
-      Downloads pages provide reuse and citation guidance. TODO: owner to confirm the applicable license
-      / terms of use before publication.
+      The PathBank About page states that the database is made available under the Open Database License.
+      The same page adds conditions that are more restrictive than ODbL alone: use or re-distribution of
+      the data, in whole or in part, for commercial purposes requires explicit permission of the authors,
+      and users who download significant portions of the database are asked to cite the PathBank
+      publication.
+    license_name: "Open Database License (ODbL)"
+    license_url: "https://opendatacommons.org/licenses/odbl/"
   data_access_locations:
     - "All downloads: https://pathbank.org/downloads"
   data_provision_mechanisms:
@@ -30,25 +35,22 @@ source_info:
     - csv
     - xml  # PWML is an XML-based markup format, parsed here with xmltodict
   data_versioning_and_releases: >-
-    PathBank does not publish an explicit, regularly-scheduled release version. Treat each pull as a dated
-    snapshot; the downloads page lists 'Generated On' timestamps and large per-format archives. The ingest
-    derives its version string from the most recent file modification date of the pathways CSV and PWML
-    archives (see get_latest_version in pathbank.py).
-  source_status: unknown
-  additional_notes:
-    - >-
-      TODO (owner decision): source_status is set to 'unknown' pending confirmation of PathBank's current
-      maintenance/update cadence. PathBank remains online and serves downloadable archives with
-      'Generated On' timestamps, but no regular release schedule is published and the primary publication
-      dates to 2020. Owner (@bazarkua) should confirm whether 'maintained_as_needed_updates' or another
-      value is more accurate.
+    PathBank does not publish an explicit, regularly-scheduled release version. Each pull is a dated
+    snapshot, and the downloads page lists a 'Generated On' timestamp per archive. The ingest derives its
+    version string from the most recent file modification date of the pathways CSV and PWML archives (see
+    get_latest_version in pathbank.py). Note that the two archives used here have not been regenerated
+    since 2019 (pathways CSV 'Aug 15 2019', PWML 'Sep 12 2019', 110,234 PWML files), so the derived version
+    currently resolves to 2019-09-13. That file count corresponds to PathBank 1.0. The PathBank 2.0 content
+    described in the 2024 publication (over 600,000 pathways) is served through the website but is not
+    present in these bulk download archives.
+  source_status: maintained_as_needed_updates
 
 ingest_info:
   ingest_categories:
     - primary_knowledge_provider
   utility: >-
-    Comprehensive pathway membership and mechanistic process data (reactions, transports, interactions,
-    complex composition, localization) for Translator reasoning and pathway-centric analytics.
+    Comprehensive pathway membership and mechanistic process data (reactions, interactions, complex
+    composition, localization) for Translator reasoning and pathway-centric analytics.
   scope: >-
     This ingest uses only two inputs: the master pathways CSV for biolink:Pathway nodes and the PWML
     archive for entities, processes, and edges. Other formats available from PathBank (BioPAX, SBML, SBGN,
@@ -68,7 +70,7 @@ ingest_info:
       fields_used: "SMPDB ID, PW ID, Name, Subject, Description"
     - file_name: "pathbank_all_pwml.zip"
       included_records: "All PWML pathway files (PW*.pwml)."
-      fields_used: "entities (compounds, proteins, complexes, nucleic acids, element collections, bounds), processes (reactions, transports, interactions), participants (inputs/outputs), enzymes/transporters, localization (subcellular compartments/tissues)"
+      fields_used: "entities (compounds, proteins, complexes, nucleic acids, element collections, bounds), processes (reactions, interactions), participants (inputs/outputs), reaction enzymes, localization (subcellular compartments/tissues)"
 
   # Note: filtered_content is omitted because all records from the included files
   # (pathbank_pathways.csv and PWML files) are used without record-level filtering.


### PR DESCRIPTION
## PathBank RIG review & completion (draft)

Auto-generated **draft** review of `src/translator_ingest/ingests/pathbank/pathbank_rig.yaml` as part of the June 2026 RIG review epic #407. Addresses #433.

@bazarkua is assigned to **review and refine** this draft (especially the owner decisions flagged below).

Validated against `resource-ingest-guide-schema` **0.1.5**:
```
uv run linkml-validate -s <schema> -C ReferenceIngestGuide src/translator_ingest/ingests/pathbank/pathbank_rig.yaml
# -> No issues found
```

### What changed
- **Removed invalid `known_issues` top-level key** — it is not a slot in the schema and was the sole hard validation error. Its content (normalization drop, missing predicates, has_participant range warnings, GO:0043165 edge case) was preserved and relocated into `target_info.additional_notes` as documented known issues.
- **Removed deprecated `target_info.infores_id`** (`infores:translator-pathbank-kgx`), matching the CTD reference RIG convention.
- **Added `source_info.source_status`** (required by this review) — set to `unknown` and flagged for owner confirmation (see below).
- **Completed `source_info.description`** — fuller narrative (Wishart Lab / SMPDB companion, pathway types, organism coverage, export formats).
- **`terms_of_use_info`** — moved the free-text guidance from `license_name` (which should be a real license name) into `terms_of_use_description`; added a TODO for the owner to confirm licensing.
- **`data_formats`**: `other` → `xml` (PWML is an XML-based markup format, parsed with xmltodict).
- **Edge-type corrections grounded in `pathbank.py` / `interaction_mapping.py`:**
  - `has_part` expanded to cover the second code path: PathBank "bound" `ChemicalEntity` nodes linking to member elements (added `ChemicalEntity` subject; added SmallMolecule/NucleicAcidEntity/MacromolecularComplex/ChemicalEntity objects), in addition to `MacromolecularComplex has_part Protein`.
  - Added `biolink:NucleicAcidEntity` to subject/object categories of `regulates`, `affects`, `physically_interacts_with`, and `interacts_with` (NucleicAcid is a valid interaction element type in the code).
  - Added clarifying `additional_notes` on qualifier application (qualifiers only present when a specialized association class applies; else generic Association) and on the excluded GO term.
- Added a `predicates` future-consideration about the keyword-based interaction-type mapping.

### Owner decisions needed (@bazarkua)
1. **`source_status`** — currently `unknown`. PathBank is online and serves timestamped archives, but no regular release cadence is published and the primary paper dates to 2020. Confirm whether `maintained_as_needed_updates` (or another value) is accurate.
2. **License / terms of use** — PathBank publishes no formal license with its downloads. Confirm the applicable terms; `license_name` was intentionally left unset.
3. **`ui_explanation` text** — drafted per edge type; review wording for UI display.

### Residual gaps
- No `edge_properties`, `aggregator_knowledge_sources`, or `supporting_data_sources` are declared, matching the code (edges carry only core fields + PathBank primary source; no publications/scores emitted).
- The known-issue notes describe a large post-normalization content loss (~88% of edges); this is an upstream NodeNorm coverage matter, not a RIG defect.
