### PR TITLE
Set an env var to force ORION to use the right bl version

### DIFF
--- a/src/translator_ingest/__init__.py
+++ b/src/translator_ingest/__init__.py
@@ -2,6 +2,7 @@
 Translator Ingest Globally Shared Code and parameters
 """
 import os
+from importlib.metadata import version
 from pathlib import Path
 
 TRANSLATOR_INGEST_PATH = Path(__file__).parent
@@ -20,3 +21,9 @@ INGEST_PARSER_DIR = INGESTS_PARSER_PATH.absolute()
 # Default public HTTPS endpoints for KGX storage (browser view format)
 INGESTS_STORAGE_URL = os.environ.get("INGESTS_STORAGE_URL", "https://kgx-storage.ci.transltr.io/data")
 INGESTS_RELEASES_URL = os.environ.get("INGESTS_RELEASES_URL", "https://kgx-storage.ci.transltr.io/releases")
+
+# BL_VERSION is an env var used by ORION to set the default version 
+# of the biolink model, used by various operations such as checking 
+# which properties are qualifiers during merging. This makes sure ORION
+# uses the same version of biolink as this repo.
+os.environ.setdefault("BL_VERSION", version("biolink-model"))

--- a/tests/unit/test_biolink_schema_loading.py
+++ b/tests/unit/test_biolink_schema_loading.py
@@ -1,7 +1,9 @@
 """
 Tests for biolink schema loading functionality in validate_biolink_kgx.py
 """
+import os
 import pytest
+from importlib.metadata import version
 from importlib.resources import files
 
 from linkml_runtime.utils.schemaview import SchemaView
@@ -50,3 +52,15 @@ def test_get_biolink_model_toolkit():
        configured with the expected project Biolink Model schema."""
     bmt: Toolkit = get_biolink_model_toolkit()
     assert bmt.get_model_version() == get_current_biolink_version()
+
+
+def test_biolink_model_distribution_version_matches_schema_version():
+    """The BL_VERSION set in translator_ingest/__init__ comes from the installed biolink-model
+       distribution, because reading it is cheap. Ensure that stays equivalent to the schema
+       version recorded in ingest metadata, so for example ORION merges on the version we claim to use."""
+    assert version("biolink-model") == get_current_biolink_version()
+
+
+def test_bl_version_env_var_is_set_for_orion():
+    """ORION reads BL_VERSION at import time to pick the Biolink Model version."""
+    assert os.environ["BL_VERSION"] == get_current_biolink_version()


### PR DESCRIPTION
ORION has an env var BL_VERSION that sets the default biolink model version to be used by the biolink model toolkit to perform a variety of operations. Setting this env var directly from the version of our installed biolink model dependency makes it run on the same version.