### PR TITLE
Fix bgee downloads: use www.bgee.org to avoid Cloudflare 403

### DIFF
--- a/src/translator_ingest/ingests/bgee/download.yaml
+++ b/src/translator_ingest/ingests/bgee/download.yaml
@@ -5,36 +5,36 @@
 ---
 # For bgee
 
-- url: https://bgee.org/ftp/current/download/calls/expr_calls/Homo_sapiens_expr_simple.tsv.gz
+- url: https://www.bgee.org/ftp/current/download/calls/expr_calls/Homo_sapiens_expr_simple.tsv.gz
   local_name: Homo_sapiens_expr_simple.tsv.gz
 
-- url: https://bgee.org/ftp/current/download/calls/expr_calls/Rattus_norvegicus_expr_simple.tsv.gz
+- url: https://www.bgee.org/ftp/current/download/calls/expr_calls/Rattus_norvegicus_expr_simple.tsv.gz
   local_name: Rattus_norvegicus_expr_simple.tsv.gz
 
-- url: https://bgee.org/ftp/current/download/calls/expr_calls/Mus_musculus_expr_simple.tsv.gz
+- url: https://www.bgee.org/ftp/current/download/calls/expr_calls/Mus_musculus_expr_simple.tsv.gz
   local_name: Mus_musculus_expr_simple.tsv.gz
 
-#- url: https://bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Sus_scrofa_expr_simple.tsv.gz
+#- url: https://www.bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Sus_scrofa_expr_simple.tsv.gz
 #  local_name: Sus_scrofa_expr_simple.tsv.gz
 #
-#- url: https://bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Bos_taurus_expr_simple.tsv.gz
+#- url: https://www.bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Bos_taurus_expr_simple.tsv.gz
 #  local_name: Bos_taurus_expr_simple.tsv.gz
 #
-#- url: https://bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Canis_lupus_familiaris_expr_simple.tsv.gz
+#- url: https://www.bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Canis_lupus_familiaris_expr_simple.tsv.gz
 #  local_name: Canis_lupus_familiaris_expr_simple.tsv.gz
 #
-#- url: https://bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Gallus_gallus_expr_simple.tsv.gz
+#- url: https://www.bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Gallus_gallus_expr_simple.tsv.gz
 #  local_name: Gallus_gallus_expr_simple.tsv.gz
 #
 #
-#- url: https://bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Danio_rerio_expr_simple.tsv.gz
+#- url: https://www.bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Danio_rerio_expr_simple.tsv.gz
 #  local_name: Danio_rerio_expr_simple.tsv.gz
 #
-#- url: https://bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Xenopus_laevis_expr_simple.tsv.gz
+#- url: https://www.bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Xenopus_laevis_expr_simple.tsv.gz
 #  local_name: Xenopus_laevis_expr_simple.tsv.gz
 #
-#- url: https://bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Drosophila_melanogaster_expr_simple.tsv.gz
+#- url: https://www.bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Drosophila_melanogaster_expr_simple.tsv.gz
 #  local_name: Drosophila_melanogaster_expr_simple.tsv.gz
 #
-#- url: https://bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Caenorhabditis_elegans_expr_simple.tsv.gz
+#- url: https://www.bgee.org/ftp/bgee_v15_0/download/calls/expr_calls/Caenorhabditis_elegans_expr_simple.tsv.gz
 #  local_name: Caenorhabditis_elegans_expr_simple.tsv.gz


### PR DESCRIPTION
## Summary

Bgee source downloads currently fail: the bare `bgee.org` host now sits behind a Cloudflare bot challenge and returns **HTTP 403** to automated clients, so all three bgee files fail to download and the pipeline's fail-fast aborts the bgee run. The `www.bgee.org` host serves the identical files with **HTTP 200**. This changes `download.yaml` to use `www.bgee.org`.

## Why only `download.yaml`

The rest of the bgee ingest already uses `www.bgee.org`:
- `bgee.py` fetches the version manifest from `https://www.bgee.org/ftp/release_v2.tsv` (with a browser User-Agent, per its own comment about bgee.org's 403).
- `bgee_rig.yaml` documents every download location as `www.bgee.org`.

Only the operative `download.yaml` was left on bare `bgee.org`. That mismatch is exactly why version detection succeeds (`Latest version for bgee established: 15.2`) while the actual data download 403s. This PR aligns `download.yaml` with the rest of the ingest.

Note: unlike the manifest fetch, `www.bgee.org` serves the data files to a plain client (a default-User-Agent `curl` gets 200), so no User-Agent handling is needed in the downloader — only the host correction.

## Verification

Confirmed on the UNC LongLeaf cluster:
- All three species files (`Homo_sapiens`, `Rattus_norvegicus`, `Mus_musculus`) download from `www.bgee.org` (HTTP 200; ~174 MB / 9 MB / 160 MB).
- `bgee.org` returns 403 for the same paths; `www.bgee.org` returns 200.
- bgee runs cleanly through transform → normalize → release: **sample validation 0 errors, 0 warnings**, release `1.0.0` produced with a freshly-populated `source_download_date` (source version 15.2).

## Files changed

- `src/translator_ingest/ingests/bgee/download.yaml` (3 active URLs + the commented-out species, all `bgee.org` → `www.bgee.org`)

https://claude.ai/code/session_01CUkhPbxVf11d2YXzHdr31N