### PR TITLE
remove target_info.infores_id from scripts

### DIFF
--- a/src/docs/scripts/create_rig.py
+++ b/src/docs/scripts/create_rig.py
@@ -40,9 +40,6 @@ def create_rig(infores_id, rig_name, output_path, template_path):
     # Set the target infores_id based on the source (optional but commonly done)
     if "target_info" not in template:
         template["target_info"] = {}
-    # TODO: should this now be something like
-    #       "infores:translator-ctd-kgx" instead of just "'"infores:ctd"?
-    template["target_info"]["infores_id"] = infores_id
 
     # Add the creation timestamp in additional_notes if not present
     if "additional_notes" not in template["source_info"]:

--- a/src/docs/scripts/rig_to_markdown.py
+++ b/src/docs/scripts/rig_to_markdown.py
@@ -127,9 +127,6 @@ def yaml_to_markdown(rig_data, rig_name):
         target = rig_data["target_info"]
         markdown += "## Target Information\n\n"
 
-        if "infores_id" in target:
-            markdown += f"**Target InfoRes ID:** {target['infores_id']}\n\n"
-
         if "edge_type_info" in target and target["edge_type_info"]:
             markdown += "### Edge Types\n\n"
             headers = [


### PR DESCRIPTION
The **target_info.infores_id** tag was removed from the RIG schema, hence we remove it from the various Translator Ingest scripts which dereference it.