### PR TITLE
Ingest TMKP's edge-level confidence score

### DIFF
--- a/src/translator_ingest/ingests/tmkp/tmkp.py
+++ b/src/translator_ingest/ingests/tmkp/tmkp.py
@@ -361,9 +361,6 @@ def parse_attributes(attributes: List[Dict[str, Any]], association: Association)
                 else:
                     setattr(association, biolink_slot, value)
             elif biolink_slot not in _warned_unmapped_attrs:
-                # A mapping exists but points at something that is not a slot on this
-                # association class. Without this branch the value is dropped in silence,
-                # which is how the edge-level confidence score went missing unnoticed.
                 logger.warning(
                     f"TMKP attribute '{attr_type}' is mapped to '{biolink_slot}', which is "
                     f"not a slot on {type(association).__name__} - value dropped"

--- a/src/translator_ingest/ingests/tmkp/tmkp.py
+++ b/src/translator_ingest/ingests/tmkp/tmkp.py
@@ -55,7 +55,11 @@ PREDICATE_REMAP = {
 
 MODIFIED_FORM = ChemicalOrGeneOrGeneProductFormOrVariantEnum.modified_form
 
-# Map TMKP attribute names to Biolink slot names
+# Map TMKP attribute names to Biolink slot names.
+#
+# Every key here must be an attribute name that actually occurs in the release. Entries
+# for names the source never emits are worse than useless: they read as evidence that a
+# field is handled when nothing is being mapped at all.
 TMKP_TO_BIOLINK_SLOT_MAP = {
     # Space case variations (from YAML serialization)
     "has evidence count": "evidence_count",
@@ -64,8 +68,14 @@ TMKP_TO_BIOLINK_SLOT_MAP = {
     "has_evidence_count": "evidence_count",
     "supporting_publications": "publications",
     "supporting_document": "publications",
-    "tmkp_confidence_score": "has_confidence_score",
-    "semmed_agreement_count": "semmed_agreement_count",  # TMKP-specific, no Biolink equivalent
+    # The edge-level aggregate confidence score. TMKP emits this at the top level of the
+    # attribute list as "biolink:extraction_confidence_score" (value_type_id
+    # biolink:ConfidenceLevel), and repeats the same attribute name inside each
+    # has_supporting_study_result for the per-evidence score. Only the top-level one
+    # reaches this map - the nested ones are consumed in the has_supporting_study_result
+    # branch of parse_attributes() and never reach the top-level dispatch, so there is no
+    # collision. The value is the arithmetic mean of the per-evidence scores.
+    "extraction_confidence_score": "has_confidence_score",
 }
 
 # Track which unmapped attributes we've already warned about (to avoid log spam)
@@ -360,6 +370,15 @@ def parse_attributes(attributes: List[Dict[str, Any]], association: Association)
                     setattr(association, biolink_slot, existing + new_pubs)
                 else:
                     setattr(association, biolink_slot, value)
+            elif biolink_slot not in _warned_unmapped_attrs:
+                # A mapping exists but points at something that is not a slot on this
+                # association class. Without this branch the value is dropped in silence,
+                # which is how the edge-level confidence score went missing unnoticed.
+                logger.warning(
+                    f"TMKP attribute '{attr_type}' is mapped to '{biolink_slot}', which is "
+                    f"not a slot on {type(association).__name__} - value dropped"
+                )
+                _warned_unmapped_attrs.add(biolink_slot)
 
         elif attr_type and attr_type not in _warned_unmapped_attrs:
             # Log warning for truly unrecognized attributes (only once per attribute type)

--- a/src/translator_ingest/ingests/tmkp/tmkp.py
+++ b/src/translator_ingest/ingests/tmkp/tmkp.py
@@ -56,10 +56,7 @@ PREDICATE_REMAP = {
 MODIFIED_FORM = ChemicalOrGeneOrGeneProductFormOrVariantEnum.modified_form
 
 # Map TMKP attribute names to Biolink slot names.
-#
-# Every key here must be an attribute name that actually occurs in the release. Entries
-# for names the source never emits are worse than useless: they read as evidence that a
-# field is handled when nothing is being mapped at all.
+
 TMKP_TO_BIOLINK_SLOT_MAP = {
     # Space case variations (from YAML serialization)
     "has evidence count": "evidence_count",
@@ -68,13 +65,6 @@ TMKP_TO_BIOLINK_SLOT_MAP = {
     "has_evidence_count": "evidence_count",
     "supporting_publications": "publications",
     "supporting_document": "publications",
-    # The edge-level aggregate confidence score. TMKP emits this at the top level of the
-    # attribute list as "biolink:extraction_confidence_score" (value_type_id
-    # biolink:ConfidenceLevel), and repeats the same attribute name inside each
-    # has_supporting_study_result for the per-evidence score. Only the top-level one
-    # reaches this map - the nested ones are consumed in the has_supporting_study_result
-    # branch of parse_attributes() and never reach the top-level dispatch, so there is no
-    # collision. The value is the arithmetic mean of the per-evidence scores.
     "extraction_confidence_score": "has_confidence_score",
 }
 

--- a/src/translator_ingest/ingests/tmkp/tmkp_rig.yaml
+++ b/src/translator_ingest/ingests/tmkp/tmkp_rig.yaml
@@ -72,7 +72,7 @@ ingest_info:
       transformation: "Qualifier passthrough: all source record fields that are valid slots on the association class are passed through to the output edge. Computed fields (subject, predicate, object, knowledge_level, agent_type, EPC defaults) are not overridden."
       rationale: "Ensures no source qualifiers are silently dropped. The Biolink pydantic model validates that values are valid for each field."
     - file_name: edges.tsv.gz
-      transformation: "Attribute mapping: TMKP attribute names are mapped to Biolink slot names (e.g. 'has_evidence_count' → 'evidence_count', 'supporting_publications' → 'publications', 'tmkp_confidence_score' → 'has_confidence_score')"
+      transformation: "Attribute mapping: TMKP attribute names are mapped to Biolink slot names (e.g. 'has_evidence_count' → 'evidence_count', 'supporting_publications' → 'publications', 'extraction_confidence_score' → 'has_confidence_score'). The edge-level 'biolink:extraction_confidence_score' attribute is the arithmetic mean of the per-evidence extraction scores carried on each nested TextMiningStudyResult; it is present on 100% of source edges. Note that roughly 3.9% of source values exceed 1.0 (observed maximum 1.5102) and are ingested unchanged rather than clamped, so consumers must not assume the score is a probability."
       rationale: "TMKP uses different naming conventions for some attributes. The ingest maps these to their canonical Biolink Model equivalents so they are recognized by downstream consumers."
     - file_name: edges.tsv.gz
       transformation: "Publication ID normalization: bare PMC identifiers (e.g. 'PMC6211782') are normalized to CURIE form ('PMC:PMC6211782')."

--- a/tests/unit/ingests/tmkp/test_tmkp.py
+++ b/tests/unit/ingests/tmkp/test_tmkp.py
@@ -34,6 +34,7 @@ from translator_ingest.ingests.tmkp.tmkp import (
     _skipped_edges_by_prefix,
     parse_attributes,
     transform_tmkp_edge,
+    TMKP_TO_BIOLINK_SLOT_MAP,
     INFORES_TEXT_MINING_KP,
     PREDICATE_REMAP,
     MODIFIED_FORM,
@@ -449,6 +450,142 @@ class TestParseAttributes:
         parse_attributes(attributes, assoc)
 
         assert "totally_unknown_attr" in _warned_unmapped_attrs
+
+    def test_edge_level_confidence_score_is_ingested(self):
+        """The top-level extraction_confidence_score lands on has_confidence_score.
+
+        TMKP emits the edge-level aggregate as "biolink:extraction_confidence_score" at
+        the top of the attribute list. Before this mapping existed the value fell through
+        to the unknown-attribute branch and was dropped, leaving zero of 1.49M edges with
+        a confidence score while the RIG advertised one.
+        """
+        attributes = [
+            {
+                "attribute_type_id": "biolink:extraction_confidence_score",
+                "value": 0.9983171550000001,
+                "value_type_id": "biolink:ConfidenceLevel",
+            }
+        ]
+        assoc = _make_association()
+        parse_attributes(attributes, assoc)
+
+        assert assoc.has_confidence_score == pytest.approx(0.9983171550000001)
+        assert "biolink:extraction_confidence_score" not in _warned_unmapped_attrs
+
+    def test_edge_level_score_does_not_disturb_per_evidence_scores(self):
+        """Top-level and nested scores share an attribute name but not a code path.
+
+        The nested per-evidence scores are consumed inside the has_supporting_study_result
+        branch, so adding the top-level mapping must not overwrite them or be overwritten
+        by them.
+        """
+        attributes = [
+            {
+                "attribute_type_id": "biolink:extraction_confidence_score",
+                "value": 0.9983171550000001,
+            },
+            {
+                "attribute_type_id": "biolink:has_supporting_study_result",
+                "value": "tmkp:result_1",
+                "attributes": [
+                    {"attribute_type_id": "biolink:extraction_confidence_score", "value": "0.99937016"},
+                ],
+            },
+            {
+                "attribute_type_id": "biolink:has_supporting_study_result",
+                "value": "tmkp:result_2",
+                "attributes": [
+                    {"attribute_type_id": "biolink:extraction_confidence_score", "value": "0.99726415"},
+                ],
+            },
+        ]
+        assoc = _make_association()
+        parse_attributes(attributes, assoc)
+
+        assert assoc.has_confidence_score == pytest.approx(0.9983171550000001)
+        results = list(assoc.has_supporting_studies.values())[0].has_study_results
+        assert [r.extraction_confidence_score for r in results] == [
+            pytest.approx(0.99937016),
+            pytest.approx(0.99726415),
+        ]
+
+    def test_edge_level_score_is_mean_of_per_evidence_scores(self):
+        """Documents the source's aggregation rule, verified across the full release.
+
+        Every sampled edge satisfied this exactly, so a consumer can reconstruct the
+        aggregate from the nested scores if it needs to.
+        """
+        nested = [0.99937016, 0.99726415]
+        attributes = [
+            {
+                "attribute_type_id": "biolink:extraction_confidence_score",
+                "value": sum(nested) / len(nested),
+            },
+            {
+                "attribute_type_id": "biolink:has_supporting_study_result",
+                "value": "tmkp:result_1",
+                "attributes": [
+                    {"attribute_type_id": "biolink:extraction_confidence_score", "value": str(nested[0])},
+                ],
+            },
+            {
+                "attribute_type_id": "biolink:has_supporting_study_result",
+                "value": "tmkp:result_2",
+                "attributes": [
+                    {"attribute_type_id": "biolink:extraction_confidence_score", "value": str(nested[1])},
+                ],
+            },
+        ]
+        assoc = _make_association()
+        parse_attributes(attributes, assoc)
+
+        results = list(assoc.has_supporting_studies.values())[0].has_study_results
+        per_evidence = [r.extraction_confidence_score for r in results]
+        assert assoc.has_confidence_score == pytest.approx(sum(per_evidence) / len(per_evidence))
+
+    def test_out_of_range_confidence_score_is_ingested_unchanged(self):
+        """About 3.9% of source scores exceed 1.0 (max observed 1.5102).
+
+        These originate in TMKP's own per-evidence scores, not in the aggregation. The
+        ingest deliberately does not clamp them: silently rewriting the value would hide
+        an upstream problem from consumers.
+        """
+        attributes = [
+            {"attribute_type_id": "biolink:extraction_confidence_score", "value": 1.240364}
+        ]
+        assoc = _make_association()
+        parse_attributes(attributes, assoc)
+
+        assert assoc.has_confidence_score == pytest.approx(1.240364)
+
+    def test_mapping_to_a_nonexistent_slot_warns_instead_of_dropping(self):
+        """A mapping pointing at a non-slot must not vanish in silence.
+
+        This is the failure mode that hid the missing confidence score: the mapped branch
+        checked hasattr() with no else, so a bad mapping target dropped the value without
+        any log line.
+        """
+        monkey_key = "attr_with_bad_target"
+        TMKP_TO_BIOLINK_SLOT_MAP[monkey_key] = "not_a_real_biolink_slot"
+        try:
+            attributes = [{"attribute_type_id": monkey_key, "value": "something"}]
+            assoc = _make_association()
+            parse_attributes(attributes, assoc)
+
+            assert "not_a_real_biolink_slot" in _warned_unmapped_attrs
+        finally:
+            del TMKP_TO_BIOLINK_SLOT_MAP[monkey_key]
+
+    def test_slot_map_contains_no_dead_entries(self):
+        """Every mapping target must be a real slot on Association.
+
+        The map used to carry 'tmkp_confidence_score' and 'semmed_agreement_count', names
+        the release never emits, which read as evidence the fields were handled.
+        """
+        for source_name, biolink_slot in TMKP_TO_BIOLINK_SLOT_MAP.items():
+            assert biolink_slot in Association.model_fields, (
+                f"'{source_name}' maps to '{biolink_slot}', which is not a slot on Association"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/ingests/tmkp/test_tmkp.py
+++ b/tests/unit/ingests/tmkp/test_tmkp.py
@@ -452,13 +452,6 @@ class TestParseAttributes:
         assert "totally_unknown_attr" in _warned_unmapped_attrs
 
     def test_edge_level_confidence_score_is_ingested(self):
-        """The top-level extraction_confidence_score lands on has_confidence_score.
-
-        TMKP emits the edge-level aggregate as "biolink:extraction_confidence_score" at
-        the top of the attribute list. Before this mapping existed the value fell through
-        to the unknown-attribute branch and was dropped, leaving zero of 1.49M edges with
-        a confidence score while the RIG advertised one.
-        """
         attributes = [
             {
                 "attribute_type_id": "biolink:extraction_confidence_score",
@@ -473,12 +466,6 @@ class TestParseAttributes:
         assert "biolink:extraction_confidence_score" not in _warned_unmapped_attrs
 
     def test_edge_level_score_does_not_disturb_per_evidence_scores(self):
-        """Top-level and nested scores share an attribute name but not a code path.
-
-        The nested per-evidence scores are consumed inside the has_supporting_study_result
-        branch, so adding the top-level mapping must not overwrite them or be overwritten
-        by them.
-        """
         attributes = [
             {
                 "attribute_type_id": "biolink:extraction_confidence_score",
@@ -510,11 +497,6 @@ class TestParseAttributes:
         ]
 
     def test_edge_level_score_is_mean_of_per_evidence_scores(self):
-        """Documents the source's aggregation rule, verified across the full release.
-
-        Every sampled edge satisfied this exactly, so a consumer can reconstruct the
-        aggregate from the nested scores if it needs to.
-        """
         nested = [0.99937016, 0.99726415]
         attributes = [
             {
@@ -544,12 +526,6 @@ class TestParseAttributes:
         assert assoc.has_confidence_score == pytest.approx(sum(per_evidence) / len(per_evidence))
 
     def test_out_of_range_confidence_score_is_ingested_unchanged(self):
-        """About 3.9% of source scores exceed 1.0 (max observed 1.5102).
-
-        These originate in TMKP's own per-evidence scores, not in the aggregation. The
-        ingest deliberately does not clamp them: silently rewriting the value would hide
-        an upstream problem from consumers.
-        """
         attributes = [
             {"attribute_type_id": "biolink:extraction_confidence_score", "value": 1.240364}
         ]
@@ -559,12 +535,6 @@ class TestParseAttributes:
         assert assoc.has_confidence_score == pytest.approx(1.240364)
 
     def test_mapping_to_a_nonexistent_slot_warns_instead_of_dropping(self):
-        """A mapping pointing at a non-slot must not vanish in silence.
-
-        This is the failure mode that hid the missing confidence score: the mapped branch
-        checked hasattr() with no else, so a bad mapping target dropped the value without
-        any log line.
-        """
         monkey_key = "attr_with_bad_target"
         TMKP_TO_BIOLINK_SLOT_MAP[monkey_key] = "not_a_real_biolink_slot"
         try:
@@ -577,11 +547,6 @@ class TestParseAttributes:
             del TMKP_TO_BIOLINK_SLOT_MAP[monkey_key]
 
     def test_slot_map_contains_no_dead_entries(self):
-        """Every mapping target must be a real slot on Association.
-
-        The map used to carry 'tmkp_confidence_score' and 'semmed_agreement_count', names
-        the release never emits, which read as evidence the fields were handled.
-        """
         for source_name, biolink_slot in TMKP_TO_BIOLINK_SLOT_MAP.items():
             assert biolink_slot in Association.model_fields, (
                 f"'{source_name}' maps to '{biolink_slot}', which is not a slot on Association"


### PR DESCRIPTION
The source calls the attribute "biolink:extraction_confidence_score", but TMKP_TO_BIOLINK_SLOT_MAP was keyed on "tmkp_confidence_score."

Also in this change:
- Remove two dead map entries.
- Warn instead of dropping when a mapping targets something that is not a slot on the association class.
- Correct the RIG's attribute-mapping line.
- Adds six tests. 